### PR TITLE
ESR now listens to the environment defined events from EP

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,8 +92,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"etos_suite_runner"
-copyright = u"2020, Axis Communications AB"
+project = "etos_suite_runner"
+copyright = "2020, Axis Communications AB"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -241,7 +241,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "user_guide.tex", u"etos_suite_runner Documentation", u"", "manual"),
+    ("index", "user_guide.tex", "etos_suite_runner Documentation", "", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "etos_suite_runner"
-copyright = "2020, Axis Communications AB"
+copyright = "Axis Communications AB"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pylintrc
+++ b/pylintrc
@@ -1,3 +1,3 @@
 [messages control]
 disable=
-    duplicate-code
+    duplicate-code,fixme

--- a/src/etos_suite_runner/__main__.py
+++ b/src/etos_suite_runner/__main__.py
@@ -155,7 +155,7 @@ class ESR:  # pylint:disable=too-many-instance-attributes
         return task_id
 
     def run_suites(self, triggered):
-        """Trigger an activity and starts the actual test runner.
+        """Start up a suite runner handling multiple suites that execute within test runners.
 
         Will only start the test activity if there's a 'slot' available.
 

--- a/src/etos_suite_runner/__main__.py
+++ b/src/etos_suite_runner/__main__.py
@@ -64,6 +64,9 @@ class ESR:  # pylint:disable=too-many-instance-attributes
     def _request_environment(self, ids):
         """Request an environment from the environment provider.
 
+        :param ids: Suite runner IDs that were generated here in order to correlate
+                    environments and the suite runners.
+        :type ids: list
         :return: Task ID and an error message.
         :rtype: tuple
         """
@@ -140,7 +143,14 @@ class ESR:  # pylint:disable=too-many-instance-attributes
                 break
 
     def _reserve_workers(self, ids):
-        """Reserve workers for test."""
+        """Reserve workers for test.
+
+        :param ids: Suite runner IDs that were generated here in order to correlate
+                    environments and the suite runners.
+        :type ids: list
+        :return: The environment provider task ID
+        :rtype: str
+        """
         LOGGER.info("Request environment from environment provider")
         task_id, msg = self._request_environment(ids)
         if task_id is None:

--- a/src/etos_suite_runner/__main__.py
+++ b/src/etos_suite_runner/__main__.py
@@ -64,8 +64,8 @@ class ESR:  # pylint:disable=too-many-instance-attributes
     def _request_environment(self, ids):
         """Request an environment from the environment provider.
 
-        :param ids: Suite runner IDs that were generated here in order to correlate
-                    environments and the suite runners.
+        :param ids: Generated suite runner IDs used to correlate environments and the suite
+                    runners.
         :type ids: list
         :return: Task ID and an error message.
         :rtype: tuple
@@ -120,14 +120,11 @@ class ESR:  # pylint:disable=too-many-instance-attributes
             if response and result:
                 break
         else:
-            if response and result:
-                self.params.set_status(response.get("status"), result.get("error"))
-            else:
-                self.params.set_status(
-                    "FAILURE",
-                    "Unknown Error: Did not receive an environment "
-                    f"within {self.etos.debug.default_http_timeout}s",
-                )
+            self.params.set_status(
+                "FAILURE",
+                "Unknown Error: Did not receive an environment "
+                f"within {self.etos.debug.default_http_timeout}s",
+            )
 
     def _release_environment(self, task_id):
         """Release an environment from the environment provider.
@@ -145,8 +142,8 @@ class ESR:  # pylint:disable=too-many-instance-attributes
     def _reserve_workers(self, ids):
         """Reserve workers for test.
 
-        :param ids: Suite runner IDs that were generated here in order to correlate
-                    environments and the suite runners.
+        :param ids: Generated suite runner IDs used to correlate environments and the suite
+                    runners.
         :type ids: list
         :return: The environment provider task ID
         :rtype: str

--- a/src/etos_suite_runner/__main__.py
+++ b/src/etos_suite_runner/__main__.py
@@ -117,7 +117,7 @@ class ESR:  # pylint:disable=too-many-instance-attributes
                 self.params.set_status(response.get("status"), result.get("error"))
             else:
                 self.params.set_status(
-                    "FAILED",
+                    "FAILURE",
                     "Unknown Error: Did not receive an environment "
                     f"within {self.etos.debug.default_http_timeout}s",
                 )

--- a/src/etos_suite_runner/__main__.py
+++ b/src/etos_suite_runner/__main__.py
@@ -67,8 +67,10 @@ class ESR:  # pylint:disable=too-many-instance-attributes
         :return: Task ID and an error message.
         :rtype: tuple
         """
-        params = {"suite_id": self.params.tercc.meta.event_id,
-                  "suite_runner_ids": ",".join(ids)}
+        params = {
+            "suite_id": self.params.tercc.meta.event_id,
+            "suite_runner_ids": ",".join(ids),
+        }
         wait_generator = self.etos.http.retry(
             "POST", self.etos.debug.environment_provider, json=params
         )

--- a/src/etos_suite_runner/lib/esr_parameters.py
+++ b/src/etos_suite_runner/lib/esr_parameters.py
@@ -123,18 +123,19 @@ class ESRParameters:
         :return: Batches.
         :rtype: list
         """
-        if self.__test_suite is None:
-            tercc = self.tercc.json
-            batch_uri = tercc.get("data", {}).get("batchesUri")
-            json_header = {"Accept": "application/json"}
-            json_response = self.etos.http.wait_for_request(
-                batch_uri,
-                headers=json_header,
-            )
-            response = {}
-            for response in json_response:
-                break
-            self.__test_suite = response
+        with self.lock:
+            if self.__test_suite is None:
+                tercc = self.tercc.json
+                batch_uri = tercc.get("data", {}).get("batchesUri")
+                json_header = {"Accept": "application/json"}
+                json_response = self.etos.http.wait_for_request(
+                    batch_uri,
+                    headers=json_header,
+                )
+                response = {}
+                for response in json_response:
+                    break
+                self.__test_suite = response
         return self.__test_suite if self.__test_suite else []
 
     @property

--- a/src/etos_suite_runner/lib/esr_parameters.py
+++ b/src/etos_suite_runner/lib/esr_parameters.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -17,6 +17,7 @@
 import os
 import json
 import logging
+from threading import Lock
 
 from packageurl import PackageURL
 from eiffellib.events import EiffelTestExecutionRecipeCollectionCreatedEvent
@@ -44,11 +45,20 @@ class ESRParameters:
     """Parameters required for ESR."""
 
     logger = logging.getLogger("ESRParameters")
+    lock = Lock()
+    __test_suite = None
 
     def __init__(self, etos):
         """ESR parameters instance."""
         self.etos = etos
         self.issuer = {"name": "ETOS Suite Runner"}
+        self.environment_status = {"status": "NOT_STARTED", "error": None}
+
+    def set_status(self, status, error):
+        """Set environment provider status."""
+        with self.lock:
+            self.environment_status["status"] = status
+            self.environment_status["error"] = error
 
     def get_node(self, response):
         """Get a single node from a GraphQL response.
@@ -105,6 +115,27 @@ class ESRParameters:
             tercc.rebuild(json.loads(os.getenv("TERCC")))
             self.etos.config.set("tercc", tercc)
         return self.etos.config.get("tercc")
+
+    @property
+    def test_suite(self):
+        """Download and return test batches.
+
+        :return: Batches.
+        :rtype: list
+        """
+        if self.__test_suite is None:
+            tercc = self.tercc.json
+            batch_uri = tercc.get("data", {}).get("batchesUri")
+            json_header = {"Accept": "application/json"}
+            json_response = self.etos.http.wait_for_request(
+                batch_uri,
+                headers=json_header,
+            )
+            response = {}
+            for response in json_response:
+                break
+            self.__test_suite = response
+        return self.__test_suite if self.__test_suite else []
 
     @property
     def product(self):

--- a/src/etos_suite_runner/lib/exceptions.py
+++ b/src/etos_suite_runner/lib/exceptions.py
@@ -1,0 +1,25 @@
+# Copyright 2022 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ESR exceptions."""
+
+
+class EnvironmentProviderException(Exception):
+    """Exception from EnvironmentProvider."""
+
+    def __init__(self, msg, task_id):
+        """Initialize with task_id."""
+        self.task_id = task_id
+        super().__init__(msg)

--- a/src/etos_suite_runner/lib/executor.py
+++ b/src/etos_suite_runner/lib/executor.py
@@ -52,8 +52,8 @@ class Executor:  # pylint:disable=too-few-public-methods
     def run_tests(self, test_suite):
         """Run tests in jenkins.
 
-        :param test_file: Tests to execute.
-        :type test_file: dict
+        :param test_suite: Tests to execute.
+        :type test_suite: dict
         """
         executor = test_suite.get("executor")
         request = executor.get("request")

--- a/src/etos_suite_runner/lib/executor.py
+++ b/src/etos_suite_runner/lib/executor.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #

--- a/src/etos_suite_runner/lib/graphql.py
+++ b/src/etos_suite_runner/lib/graphql.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 """Graphql query handler module."""
 from .graphql_queries import (
-    ACTIVITY_TRIGGERED,
     TEST_SUITE_STARTED,
     TEST_SUITE_FINISHED,
     ENVIRONMENTS,
@@ -36,39 +35,17 @@ def request(etos, query):
     yield from wait_generator
 
 
-def request_activity(etos, suite_id):
-    """Request an activity event from graphql.
-
-    :param etos: ETOS client instance.
-    :type etos: :obj:`etos_lib.etos.Etos`
-    :param suite_id: ID of execution recipe triggering this activity.
-    :type suite_id: str
-    :return: Response from graphql or None
-    :rtype: dict or None
-    """
-    for response in request(etos, ACTIVITY_TRIGGERED % suite_id):
-        if response:
-            try:
-                _, activity = next(
-                    etos.graphql.search_for_nodes(response, "activityTriggered")
-                )
-            except StopIteration:
-                return None
-            return activity
-    return None
-
-
-def request_test_suite_started(etos, activity_id):
+def request_test_suite_started(etos, main_suite_id):
     """Request test suite started from graphql.
 
     :param etos: ETOS client instance.
     :type etos: :obj:`etos_lib.etos.Etos`
-    :param activity_id: ID of activity in which the test suites started
-    :type activity_id: str
+    :param main_suite_id: ID of test suite which caused the test suites started
+    :type main_suite_id: str
     :return: Iterator of test suite started graphql responses.
     :rtype: iterator
     """
-    for response in request(etos, TEST_SUITE_STARTED % activity_id):
+    for response in request(etos, TEST_SUITE_STARTED % main_suite_id):
         if response:
             for _, test_suite_started in etos.graphql.search_for_nodes(
                 response, "testSuiteStarted"

--- a/src/etos_suite_runner/lib/graphql.py
+++ b/src/etos_suite_runner/lib/graphql.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -18,6 +18,7 @@ from .graphql_queries import (
     ACTIVITY_TRIGGERED,
     TEST_SUITE_STARTED,
     TEST_SUITE_FINISHED,
+    ENVIRONMENTS,
 )
 
 
@@ -101,5 +102,25 @@ def request_test_suite_finished(etos, test_suite_ids):
                 response, "testSuiteFinished"
             ):
                 yield test_suite_finished
+            return None  # StopIteration
+    return None  # StopIteration
+
+
+def request_environment_defined(etos, activity_id):
+    """Request environment defined from graphql.
+
+    :param etos: ETOS client instance.
+    :type etos: :obj:`etos_lib.etos.Etos`
+    :param activity_id: ID of activity in which the environment defined are sent
+    :type activity_id: str
+    :return: Iterator of environment defined graphql responses.
+    :rtype: iterator
+    """
+    for response in request(etos, ENVIRONMENTS % activity_id):
+        if response:
+            for _, environment in etos.graphql.search_for_nodes(
+                response, "environmentDefined"
+            ):
+                yield environment
             return None  # StopIteration
     return None  # StopIteration

--- a/src/etos_suite_runner/lib/graphql_queries.py
+++ b/src/etos_suite_runner/lib/graphql_queries.py
@@ -14,23 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Graphql queries."""
-ACTIVITY_TRIGGERED = """
-{
-  activityTriggered(search: "{'links.type': 'CAUSE', 'links.target': '%s'}") {
-    edges {
-      node {
-        meta {
-          id
-        }
-      }
-    }
-  }
-}
-"""
-
 TEST_SUITE_STARTED = """
 {
-  testSuiteStarted(search:"{'links.type': 'CONTEXT', 'links.target': '%s'}") {
+  testSuiteStarted(search:"{'links.type': 'CAUSE', 'links.target': '%s'}") {
     edges {
       node {
         data {

--- a/src/etos_suite_runner/lib/graphql_queries.py
+++ b/src/etos_suite_runner/lib/graphql_queries.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Axis Communications AB.
+# Copyright 2020-2022 Axis Communications AB.
 #
 # For a full list of individual contributors, please see the commit history.
 #
@@ -56,6 +56,24 @@ TEST_SUITE_FINISHED = """
           testSuiteOutcome {
             verdict
           }
+        }
+      }
+    }
+  }
+}
+"""
+
+ENVIRONMENTS = """
+{
+  environmentDefined(search:"{'links.type': 'CONTEXT', 'links.target': '%s'}") {
+    edges {
+      node {
+        data {
+          name
+          uri
+        }
+        meta {
+          id
         }
       }
     }

--- a/src/etos_suite_runner/lib/log_filter.py
+++ b/src/etos_suite_runner/lib/log_filter.py
@@ -40,7 +40,7 @@ class DuplicateFilter:
         :return: Whether or not to filter.
         :rtype: bool
         """
-        msg = str(record.msg)
+        msg = "%s%s" % (record.msg, record.args)
         is_duplicate = msg in self.msgs
         if not is_duplicate:
             self.msgs.append(msg)

--- a/src/etos_suite_runner/lib/log_filter.py
+++ b/src/etos_suite_runner/lib/log_filter.py
@@ -40,7 +40,7 @@ class DuplicateFilter:
         :return: Whether or not to filter.
         :rtype: bool
         """
-        msg = "%s%s" % (record.msg, record.args)
+        msg = f"{record.msg}{record.args}"
         is_duplicate = msg in self.msgs
         if not is_duplicate:
             self.msgs.append(msg)

--- a/src/etos_suite_runner/lib/result_handler.py
+++ b/src/etos_suite_runner/lib/result_handler.py
@@ -40,7 +40,10 @@ class ResultHandler:
     @property
     def has_started(self):
         """Whether or not test suites have started."""
-        return len(self.events.get("subSuiteStarted", [])) == self.expected_number_of_suites
+        return (
+            len(self.events.get("subSuiteStarted", []))
+            == self.expected_number_of_suites
+        )
 
     @property
     def has_finished(self):
@@ -95,30 +98,29 @@ class ResultHandler:
                 description = "No description received from ESR or ETR."
         return verdict, conclusion, description
 
-    def get_events(self, suite_id):
+    def get_events(self):
         """Get events from an activity started from suite id.
 
-        :param suite_id: ID of test execution recipe that triggered this activity.
-        :type suite_id: str
         :return: Dictionary of all events generated for this suite.
         :rtype: dict
         """
         self.logger.info("Requesting events from GraphQL")
-        self.logger.info("Expected number of suites: %r", self.expected_number_of_suites)
+        self.logger.info(
+            "Expected number of suites: %r", self.expected_number_of_suites
+        )
 
         events = {
             "subSuiteStarted": [],
             "subSuiteFinished": [],
         }
-        self.logger.info("Main suite: %r", self.test_suite_started["meta"]["id"])
-        if len(self.events.get("subSuiteStarted", [])) != self.expected_number_of_suites:
+        main_suite_id = self.test_suite_started["meta"]["id"]
+        self.logger.info("Main suite: %r", main_suite_id)
+        if (
+            len(self.events.get("subSuiteStarted", []))
+            != self.expected_number_of_suites
+        ):
             self.logger.info("Getting subSuiteStarted")
-            started = [
-                test_suite_started
-                for test_suite_started in request_test_suite_started(
-                    self.etos, self.test_suite_started["meta"]["id"]
-                )
-            ]
+            started = list(request_test_suite_started(self.etos, main_suite_id))
             if not started:
                 self.logger.info("No subSuitesStarted yet.")
                 self.events = events
@@ -131,7 +133,10 @@ class ResultHandler:
         started_ids = [
             test_suite_started["meta"]["id"] for test_suite_started in started
         ]
-        if len(self.events.get("subSuiteFinished", [])) != self.expected_number_of_suites:
+        if (
+            len(self.events.get("subSuiteFinished", []))
+            != self.expected_number_of_suites
+        ):
             self.logger.info("Getting subSuiteFinished")
             finished = list(request_test_suite_finished(self.etos, started_ids))
             if not finished:
@@ -149,7 +154,6 @@ class ResultHandler:
         :param expected: Expected number of test suites.
         :type expected: int
         """
-        tercc = self.etos.config.get("tercc")
         self.expected_number_of_suites = expected
 
         timeout = time.time() + self.etos.debug.default_test_result_timeout
@@ -157,7 +161,7 @@ class ResultHandler:
         with DuplicateFilter(self.logger):
             while time.time() < timeout:
                 time.sleep(10)
-                self.get_events(tercc.meta.event_id)
+                self.get_events()
                 self.logger.info(
                     "Expected number of test suites: %r, currently active: %r",
                     self.expected_number_of_suites,

--- a/src/etos_suite_runner/lib/result_handler.py
+++ b/src/etos_suite_runner/lib/result_handler.py
@@ -18,7 +18,6 @@ import time
 import logging
 from .log_filter import DuplicateFilter
 from .graphql import (
-    request_activity,
     request_test_suite_finished,
     request_test_suite_started,
 )
@@ -27,19 +26,21 @@ from .graphql import (
 class ResultHandler:
     """ESR test result handler."""
 
-    activity_id = None
-    logger = logging.getLogger("ESR - ResultHandler")
+    results = None
+    expected_number_of_suites = 0
 
-    def __init__(self, etos):
+    def __init__(self, etos, test_suite_started):
         """ESR test result handler."""
         self.etos = etos
+        self.test_suite_started = test_suite_started.json
+        test_suite_name = self.test_suite_started["meta"]["id"]
+        self.logger = logging.getLogger(f"ESR - ResultHandler({test_suite_name})")
         self.events = {}
 
     @property
     def has_started(self):
         """Whether or not test suites have started."""
-        expected_number_of_suites = self.etos.config.get("nbr_of_suites")
-        return len(self.events.get("subSuiteStarted", [])) == expected_number_of_suites
+        return len(self.events.get("subSuiteStarted", [])) == self.expected_number_of_suites
 
     @property
     def has_finished(self):
@@ -54,8 +55,7 @@ class ResultHandler:
         if not self.events.get("subSuiteFinished"):
             return False
         nbr_of_finished = len(self.events.get("subSuiteFinished"))
-        expected_number_of_suites = self.etos.config.get("nbr_of_suites")
-        return nbr_of_finished == expected_number_of_suites
+        return nbr_of_finished == self.expected_number_of_suites
 
     @property
     def test_suites_finished(self):
@@ -73,7 +73,7 @@ class ResultHandler:
         conclusion = "SUCCESSFUL"
         description = ""
 
-        if self.etos.config.get("results") is None:
+        if self.results is None:
             verdict = "INCONCLUSIVE"
             conclusion = "FAILED"
             description = "Did not receive test results from sub suites."
@@ -104,32 +104,20 @@ class ResultHandler:
         :rtype: dict
         """
         self.logger.info("Requesting events from GraphQL")
-        if self.activity_id is None:
-            self.logger.info("Getting activity ID.")
-            activity = request_activity(self.etos, suite_id)
-            if activity is None:
-                self.logger.warning("Activity ID not found yet.")
-                return
-            self.logger.info("Activity id: %r", activity["meta"]["id"])
-            self.activity_id = activity["meta"]["id"]
-
-        expected_number_of_suites = self.etos.config.get("nbr_of_suites")
-        self.logger.info("Expected number of suites: %r", expected_number_of_suites)
+        self.logger.info("Expected number of suites: %r", self.expected_number_of_suites)
 
         events = {
             "subSuiteStarted": [],
             "subSuiteFinished": [],
         }
-        main_suite = self.etos.config.get("test_suite_started")
-        self.logger.info("Main suite: %r", main_suite["meta"]["id"])
-        if len(self.events.get("subSuiteStarted", [])) != expected_number_of_suites:
+        self.logger.info("Main suite: %r", self.test_suite_started["meta"]["id"])
+        if len(self.events.get("subSuiteStarted", [])) != self.expected_number_of_suites:
             self.logger.info("Getting subSuiteStarted")
             started = [
                 test_suite_started
                 for test_suite_started in request_test_suite_started(
-                    self.etos, self.activity_id
+                    self.etos, self.test_suite_started["meta"]["id"]
                 )
-                if test_suite_started["meta"]["id"] != main_suite["meta"]["id"]
             ]
             if not started:
                 self.logger.info("No subSuitesStarted yet.")
@@ -143,7 +131,7 @@ class ResultHandler:
         started_ids = [
             test_suite_started["meta"]["id"] for test_suite_started in started
         ]
-        if len(self.events.get("subSuiteFinished", [])) != expected_number_of_suites:
+        if len(self.events.get("subSuiteFinished", [])) != self.expected_number_of_suites:
             self.logger.info("Getting subSuiteFinished")
             finished = list(request_test_suite_finished(self.etos, started_ids))
             if not finished:
@@ -155,9 +143,14 @@ class ResultHandler:
         events["subSuiteFinished"] = self.events.get("subSuiteFinished", [])
         self.events = events
 
-    def wait_for_test_suite_finished(self):
-        """Wait for test suites to finish."""
+    def wait_for_test_suite_finished(self, expected):
+        """Wait for test suites to finish.
+
+        :param expected: Expected number of test suites.
+        :type expected: int
+        """
         tercc = self.etos.config.get("tercc")
+        self.expected_number_of_suites = expected
 
         timeout = time.time() + self.etos.debug.default_test_result_timeout
         print_once = False
@@ -165,10 +158,9 @@ class ResultHandler:
             while time.time() < timeout:
                 time.sleep(10)
                 self.get_events(tercc.meta.event_id)
-                expected_number_of_suites = self.etos.config.get("nbr_of_suites")
                 self.logger.info(
                     "Expected number of test suites: %r, currently active: %r",
-                    expected_number_of_suites,
+                    self.expected_number_of_suites,
                     len(self.events.get("subSuiteStarted", [])),
                 )
                 if not self.has_started:
@@ -178,7 +170,7 @@ class ResultHandler:
                     self.logger.info("Test suites have started.")
                 if self.has_finished:
                     self.logger.info("Test suites have finished.")
-                    self.etos.config.set("results", self.events)
+                    self.results = self.events
                     return True
 
                 self.logger.info("Waiting for test suites to finish.")

--- a/src/etos_suite_runner/lib/runner.py
+++ b/src/etos_suite_runner/lib/runner.py
@@ -16,7 +16,7 @@
 """ETOS suite runner executor."""
 import logging
 import time
-from threading import Lock
+from threading import Lock, Thread
 from multiprocessing.pool import ThreadPool
 
 from etos_lib.logging.logger import FORMAT_CONFIG
@@ -38,6 +38,8 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
     """
 
     lock = Lock()
+    environment_provider_done = False
+    error = False
     logger = logging.getLogger("ESR - Runner")
 
     def __init__(self, params, etos, context):
@@ -53,6 +55,7 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         self.params = params
         self.etos = etos
         self.context = context
+        self.sub_suites = {}
 
     def _release_environment(self, task_id):
         """Release an environment from the environment provider.
@@ -73,6 +76,55 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         :param environment: Environment which to execute in.
         :type environment: dict
         """
+        executor = Executor(self.etos)
+        executor.run_tests(environment)
+
+    def _environments(self):
+        """Get environments for all test suites in this ETOS run."""
+        FORMAT_CONFIG.identifier = self.params.tercc.meta.event_id
+        downloaded = []
+        status = {
+            "status": "FAILURE",
+            "error": "Couldn't collect any error information",
+        }
+        timeout = time.time() + self.etos.config.get("WAIT_FOR_ENVIRONMENT_TIMEOUT")
+        while time.time() < timeout:
+            status = self.params.environment_status
+            self.logger.info(status)
+            for environment in request_environment_defined(self.etos, self.context):
+                if environment["meta"]["id"] in downloaded:
+                    continue
+                suite = self._download_sub_suite(environment)
+                if self.error:
+                    break
+                downloaded.append(environment["meta"]["id"])
+                if suite is None:  # Not a real sub suite environment defined event.
+                    continue
+                with self.lock:
+                    self.sub_suites.setdefault(suite["test_suite_started_id"], [])
+                    self.sub_suites[suite["test_suite_started_id"]].append(suite)
+            # We must have found at least one environment for each test suite.
+            if status["status"] != "PENDING" and len(downloaded) >= len(
+                self.params.test_suite
+            ):
+                self.environment_provider_done = True
+                break
+            time.sleep(5)
+        if status["status"] == "FAILURE":
+            self.error = EnvironmentProviderException(
+                status["error"], self.etos.config.get("task_id")
+            )
+
+    def _download_sub_suite(self, environment):
+        """Download a sub suite from an EnvironmentDefined event.
+
+        :param environment: Environment defined event to download from.
+        :type environment: dict
+        :return: Downloaded sub suite information.
+        :rtype: dict
+        """
+        if environment["data"].get("uri") is None:
+            return None
         uri = environment["data"]["uri"]
         json_header = {"Accept": "application/json"}
         json_response = self.etos.http.wait_for_request(
@@ -83,46 +135,28 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         for suite in json_response:
             break
         else:
-            raise Exception("Could not download sub suite instructions")
+            self.error = Exception("Could not download sub suite instructions")
+        return suite
 
-        executor = Executor(self.etos)
-        executor.run_tests(suite)
+    def _sub_suites(self, main_suite_id):
+        """Get all sub suites that correlates with ID.
 
-    def _environments(self, suite_name):
-        """Get environments for a specific test suite.
-
-        :param suite_name: Since environment defined events have a name starting with 'suite_name'
-                           we will use this as a part of getting the environments.
-        :type suite_name: str
-        :return: Test suite environments.
-        :rtype: iterator
+        :param main_suite_id: Main suite ID to correlate sub suites to.
+        :type main_suite_id: str
+        :return: Each correlated sub suite.
+        :rtype: Iterator
         """
-        yielded = []
-        status = {
-            "status": "FAILURE",
-            "error": "Couldn't collect any error information",
-        }
-        timeout = time.time() + self.etos.config.get("WAIT_FOR_ENVIRONMENT_TIMEOUT")
-        while time.time() < timeout:
+        while not self.error:
+            downloaded_all = self.environment_provider_done
             time.sleep(1)
-            status = self.params.environment_status
-            self.logger.info(status)
-            for environment in request_environment_defined(self.etos, self.context):
-                self.logger.info(environment)
-                # TODO: Using the name here is volatile.
-                if not environment["data"]["name"].startswith(suite_name):
-                    continue
-                if environment["meta"]["id"] in yielded:
-                    continue
-                yielded.append(environment["meta"]["id"])
-                yield environment
-            # We must have found at least one environment.
-            if status["status"] != "PENDING" and len(yielded) > 0:
+            with self.lock:
+                sub_suites = self.sub_suites.get(main_suite_id, []).copy()
+            for sub_suite in sub_suites:
+                with self.lock:
+                    self.sub_suites[main_suite_id].remove(sub_suite)
+                yield sub_suite
+            if downloaded_all:
                 break
-        if status["status"] == "FAILURE":
-            raise EnvironmentProviderException(
-                status["error"], self.etos.config.get("task_id")
-            )
 
     def start_sub_suites(self, suite):
         """Start up all sub suites within a TERCC suite.
@@ -139,12 +173,12 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         )
         self.logger.info("Starting sub suites for %r", suite_name)
         started = []
-        for environment in self._environments(suite_name):
-            started.append(environment)
+        for sub_suite in self._sub_suites(suite["test_suite_started_id"]):
+            started.append(sub_suite)
 
-            self.logger.info("Triggering sub suite %r", environment["data"]["name"])
-            self._run_etr(environment)
-            self.logger.info("%r Triggered", environment["data"]["name"])
+            self.logger.info("Triggering sub suite %r", sub_suite["name"])
+            self._run_etr(sub_suite)
+            self.logger.info("%r Triggered", sub_suite["name"])
             time.sleep(1)
         self.logger.info("All %d sub suites for %r started", len(started), suite_name)
 
@@ -203,16 +237,19 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
                     "description": description,
                 },
             )
-
-            # TODO: This should be released using the environment defined ID
-            # when that is supported.
-            task_id = self.etos.config.get("task_id")
-            self.logger.info("Release test environment.")
-            if task_id is not None:
-                self._release_environment(task_id)
+            # TODO: Add releasing of environment defined IDs when that is supported
         self.logger.info("Test suite finished.")
 
     def start_suites_and_wait(self):
         """Get environments and start all test suites."""
-        with ThreadPool() as pool:
-            pool.map(self.start_suite, self.params.test_suite)
+        Thread(target=self._environments, daemon=True).start()
+        try:
+            with ThreadPool() as pool:
+                pool.map(self.start_suite, self.params.test_suite)
+            if self.error:
+                raise self.error
+        finally:
+            task_id = self.etos.config.get("task_id")
+            self.logger.info("Release test environment.")
+            if task_id is not None:
+                self._release_environment(task_id)


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: eiffel-community/etos#126

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
ESR will now listen to environment defined from environment provider, enabling us to easier implement sequential execution and partial check-in of environments and some preparations have been made to get there.
This change is tested locally against the environment provider version in a PR.

There are a few TODOs in the code. These will be fixed when we continue with this path. Some requirements in different parts of ETOS that need to be implemented to get there.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We've discussed several alternatives offline. This one was selected as it was the easiest to understand and it utilizes the Eiffel protocol best.

### Benefits
<!-- What benefits will be realized by the change? -->
Right now there are no real benefits to this, but in the future this will be vital for a few new features for ETOS as I hinted at in the description.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
A bit more volatile due to listening to events instead of APIs. Tried to remedy by waiting for the environment provider status in a thread and having a few robust HTTP waits.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
