### PR TITLE
Add more logging to ESR to help debug hanging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/*
 .settings
 .idea
 tags
+.tags
 
 # Package files
 *.egg

--- a/src/etos_suite_runner/lib/suite.py
+++ b/src/etos_suite_runner/lib/suite.py
@@ -186,6 +186,7 @@ class TestSuite:
         threads = []
         assigner = None
         try:
+            self.logger.info("Waiting for all sub suite environments")
             for sub_suite_definition in self.sub_suite_definitions:
                 sub_suite = SubSuite(self.etos, sub_suite_definition)
                 with self.lock:
@@ -195,6 +196,7 @@ class TestSuite:
                 )
                 threads.append(thread)
                 thread.start()
+            self.logger.info("All sub suite environments received and sub suites triggered")
 
             self.logger.info("Assigning test suite started events to sub suites")
             assigner = threading.Thread(target=self._assign_test_suite_started)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ envlist = py3,black,pylint,pydocstyle
 #     -r{toxinidir}/test-requirements.txt
 # commands =
 #     pytest -s --log-format="%(levelname)s: %(message)s" {posargs}
- 
+
 [testenv:black]
 deps =
     black


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
We are seeing some hanging jobs on ETOS master that we don't see on the latest release. This change will add more logging to help with the debugging.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
There's a lot more information that could be printed, but I want this information to be good even after debugging is finished.

### Benefits
<!-- What benefits will be realized by the change? -->
More information about what might go wrong. Especially good now that ESR has become a bit more complex.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
Could be too much unnecessary information if we continue. I don't see how this change would cause it though.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
