### PR TITLE
Remove suite assigner

### DIFF
--- a/src/etos_suite_runner/lib/suite.py
+++ b/src/etos_suite_runner/lib/suite.py
@@ -56,6 +56,7 @@ class SubSuite:
                 # "_SubSuite_\d" part of the name is set by ETOS and not humans.
                 if self.environment.get("name") == test_suite_started["data"]["name"]:
                     self.test_suite_started = test_suite_started
+                    break
         return bool(self.test_suite_started)
 
     def request_finished_event(self):

--- a/src/etos_suite_runner/lib/suite.py
+++ b/src/etos_suite_runner/lib/suite.py
@@ -210,8 +210,6 @@ class TestSuite:
                 thread.start()
             self.logger.info("All sub suite environments received and sub suites triggered")
 
-            self.logger.info("Assigning test suite started events to sub suites")
-
             if self.params.error:
                 self.logger.error("Environment provider error: %r", self.params.error)
                 self._announce(

--- a/src/etos_suite_runner/lib/suite.py
+++ b/src/etos_suite_runner/lib/suite.py
@@ -31,14 +31,14 @@ class SubSuite:
 
     released = False
 
-    def __init__(self, etos, environment):
+    def __init__(self, etos, environment, main_suite_id):
         """Initialize a sub suite."""
         self.etos = etos
         self.environment = environment
-        self.name = self.environment.get("name")
-        self.logger = logging.getLogger(f"SubSuite - {self.name}")
+        self.main_suite_id = main_suite_id
+        self.logger = logging.getLogger(f"SubSuite - {self.environment.get('name')}")
         self.logger.addFilter(DuplicateFilter(self.logger))
-        self.test_suite_started = {}  # This is set by a different thread.
+        self.test_suite_started = {}
         self.test_suite_finished = {}
 
     @property
@@ -49,6 +49,13 @@ class SubSuite:
     @property
     def started(self):
         """Whether or not this sub suite has started."""
+        if not bool(self.test_suite_started):
+            for test_suite_started in request_test_suite_started(self.etos, self.main_suite_id):
+                # Using name to match here is safe because we're only searching for
+                # sub suites that are connected to this test_suite_started ID and the
+                # "_SubSuite_\d" part of the name is set by ETOS and not humans.
+                if self.environment.get("name") == test_suite_started["data"]["name"]:
+                    self.test_suite_started = test_suite_started
         return bool(self.test_suite_started)
 
     def request_finished_event(self):
@@ -86,7 +93,7 @@ class SubSuite:
         timeout = time.time() + self.etos.debug.default_test_result_timeout
         try:
             while time.time() < timeout:
-                time.sleep(1)
+                time.sleep(10)
                 if not self.started:
                     continue
                 self.logger.info("ETR started.")
@@ -188,11 +195,12 @@ class TestSuite:
 
         self.logger.info("Starting sub suites")
         threads = []
-        assigner = None
         try:
             self.logger.info("Waiting for all sub suite environments")
             for sub_suite_definition in self.sub_suite_definitions:
-                sub_suite = SubSuite(self.etos, sub_suite_definition)
+                sub_suite = SubSuite(
+                    self.etos, sub_suite_definition, self.suite["test_suite_started_id"]
+                )
                 with self.lock:
                     self.sub_suites.append(sub_suite)
                 thread = threading.Thread(
@@ -203,8 +211,6 @@ class TestSuite:
             self.logger.info("All sub suite environments received and sub suites triggered")
 
             self.logger.info("Assigning test suite started events to sub suites")
-            assigner = threading.Thread(target=self._assign_test_suite_started)
-            assigner.start()
 
             if self.params.error:
                 self.logger.error("Environment provider error: %r", self.params.error)
@@ -219,58 +225,9 @@ class TestSuite:
             self.logger.info("All %d sub suites triggered", number_of_suites)
             self.started = True
         finally:
-            if assigner is not None:
-                assigner.join()
             for thread in threads:
                 thread.join()
         self.logger.info("All %d sub suites finished", number_of_suites)
-
-    def _assign_test_suite_started(self):
-        """Assign test suite started events to all sub suites."""
-        FORMAT_CONFIG.identifier = self.params.tercc.meta.event_id
-        timeout = time.time() + self.etos.debug.default_test_result_timeout
-        self.logger.info("Assigning test suite started to sub suites")
-        # Number of TestSuiteStarted assigned to :obj:`SubSuite` instances.
-        number_of_assigned = 0
-        while time.time() < timeout:
-            time.sleep(1)
-            suites = []
-            with self.lock:
-                sub_suites = self.sub_suites.copy()
-            if len(sub_suites) == 0 and self.params.error:
-                self.logger.info("Environment provider error")
-                return
-            if len(sub_suites) == 0:
-                self.logger.info("No sub suites started just yet")
-                continue
-            for test_suite_started in request_test_suite_started(
-                self.etos, self.suite["test_suite_started_id"]
-            ):
-                self.logger.info("Found test suite started")
-                suites.append(test_suite_started)
-                for sub_suite in sub_suites:
-                    self.logger.info("SubSuite        : %s", sub_suite.name)
-                    self.logger.info("TestSuiteStarted: %s", test_suite_started["data"]["name"])
-                    if sub_suite.started:
-                        continue
-                    # Using name to match here is safe because we're only searching for
-                    # sub suites that are connected to this test_suite_started ID and the
-                    # "_SubSuite_\d" part of the name is set by ETOS and not humans.
-                    if sub_suite.name == test_suite_started["data"]["name"]:
-                        number_of_assigned += 1
-                        self.logger.info("Test suite started assigned to %r", sub_suite.name)
-                        sub_suite.test_suite_started = test_suite_started
-                    else:
-                        self.logger.info(
-                            "No assigned test suite started for %r",
-                            test_suite_started["data"]["name"],
-                        )
-            if number_of_assigned == 0:
-                self.logger.info("Found no test suite started to assign to sub suites yet")
-                continue
-            if len(suites) == len(sub_suites) and len(sub_suites) == number_of_assigned:
-                self.logger.info("All %d sub suites started", len(sub_suites))
-                break
 
     def release_all(self):
         """Release all, unreleased, sub suites."""


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Sometimes the ESR would hang while waiting for sub suites to start, causing the assigner to not start which would result in sub suites never being able to finish and release their environments.
Now the sub suites will control themselves instead which will make this more robust.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I could fix the assigner and start it earlier, however I never really liked the design of the assigner. If we want to reduce the ER hammering we should investigate another, better, solution for that.

### Benefits
<!-- What benefits will be realized by the change? -->
We will be able to run permutation suites properly.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
We hammer the ER more.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
