### PR TITLE
Check that at least one sub suite is started

### DIFF
--- a/tests/scenario/tercc.py
+++ b/tests/scenario/tercc.py
@@ -312,3 +312,24 @@ TERCC_SUB_SUITES = {
     },
     "links": [{"type": "CAUSE", "target": "349f9bf9-0fc7-4dd4-b641-ac5f1c9ea7aa"}],
 }
+
+
+TERCC_EMPTY = {
+    "data": {
+        "selectionStrategy": {"id": "6e922b03-1323-42ca-9cf8-34427ea13f2b"},
+        "batches": [
+            {
+                "name": "Suite",
+                "priority": 1,
+                "recipes": [],
+            },
+        ],
+    },
+    "meta": {
+        "type": "EiffelTestExecutionRecipeCollectionCreatedEvent",
+        "id": "6e8ec0be-3299-4242-b07c-1843113c350f",
+        "time": 1664260578384,
+        "version": "4.1.1",
+    },
+    "links": [{"type": "CAUSE", "target": "349f9bf9-0fc7-4dd4-b641-ac5f1c9ea7aa"}],
+}

--- a/tests/scenario/test_regular.py
+++ b/tests/scenario/test_regular.py
@@ -26,7 +26,7 @@ from etos_lib.lib.config import Config
 
 from etos_suite_runner.esr import ESR
 
-from tests.scenario.tercc import TERCC, TERCC_SUB_SUITES
+from tests.scenario.tercc import TERCC, TERCC_SUB_SUITES, TERCC_EMPTY
 from tests.library.fake_server import FakeServer
 from tests.library.handler import Handler
 
@@ -152,6 +152,54 @@ class TestRegularScenario(TestCase):
 
                 self.logger.info("STEP: Verify that all events were sent and in the correct order.")
                 self.validate_event_name_order(Debug().events_published.copy())
+            finally:
+                # If the _get_environment_status method in ESR does not time out before the test
+                # finishes there will be loads of tracebacks in the log. Won't fail the test but
+                # the noise is immense.
+                while time.time() <= end:
+                    time.sleep(1)
+
+    def test_esr_without_recipes(self):
+        """Test ESR using 1 suite without any recipes.
+
+        Approval criteria:
+            - ESR shall exit early if there are no recipes to test.
+
+        Test steps:
+            1. Start up a fake server.
+            2. Initialize and run ESR.
+            3. Verify that the ESR exits.
+        """
+        os.environ["TERCC"] = json.dumps(TERCC_EMPTY)
+        tercc = json.loads(os.environ["TERCC"])
+
+        handler = partial(Handler, tercc)
+        end = time.time() + 25
+        self.logger.info("STEP: Start up a fake server.")
+        with FakeServer(handler) as server:
+            os.environ["ETOS_GRAPHQL_SERVER"] = server.host
+            os.environ["ETOS_ENVIRONMENT_PROVIDER"] = server.host
+
+            self.logger.info("STEP: Initialize and run ESR.")
+            esr = ESR()
+            try:
+                esr.run()
+                finshed = None
+                for event in Debug().events_published.copy():
+                    if event.meta.type == "EiffelTestSuiteFinishedEvent":
+                        finished = event
+                        break
+                self.logger.info("STEP: Verify that the ESR exits.")
+                assert (
+                    finished is not None
+                ), "EiffelTestSuiteFinished was not sent when test suite is empty"
+                outcome = finished.json.get("data", {}).get("outcome", {})
+                assert (
+                    outcome.get("conclusion") == "FAILED"
+                ), "Conclusion was not FAILED when test suite is empty"
+                assert (
+                    outcome.get("verdict") == "INCONCLUSIVE"
+                ), "Verdict was not INCONCLUSIVE when test suite is empty"
             finally:
                 # If the _get_environment_status method in ESR does not time out before the test
                 # finishes there will be loads of tracebacks in the log. Won't fail the test but

--- a/tests/scenario/test_regular.py
+++ b/tests/scenario/test_regular.py
@@ -184,7 +184,7 @@ class TestRegularScenario(TestCase):
             esr = ESR()
             try:
                 esr.run()
-                finshed = None
+                finished = None
                 for event in Debug().events_published.copy():
                     if event.meta.type == "EiffelTestSuiteFinishedEvent":
                         finished = event


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
N/A

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Check that we've received at least one sub suite environment before exiting the loop. Also added some checks for test suite recipe size so that we can cleanly exit if there's no chance to get environments from the environment provider.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None that I can think of right now. I kinda want to rewrite large parts of this again since it feels extremely fragile.

### Benefits
<!-- What benefits will be realized by the change? -->
We won't exit with `All 0 sub suites finished` anymore.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
If there's a problem somewhere in the environment provider where the activity finished does not have a proper conclusion set, then we can hang in this loop. It will only hang for `WAIT_FOR_ENVIRONMENT_TIMEOUT` seconds so it can be controlled.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
