### PR TITLE
Get file lock before terminating

### DIFF
--- a/projects/log_listener/src/log_listener/__main__.py
+++ b/projects/log_listener/src/log_listener/__main__.py
@@ -53,6 +53,7 @@ def main():
     def stop(*_):
         """Stop the listener."""
         if listener.is_alive():
+            LOCK.acquire(timeout=300)
             listener.clear()
             listener.stop()
             listener.join()


### PR DESCRIPTION
### Applicable Issues
N/A

### Description of the Change
We will try (or wait patiently for 5 min) to get the file lock before terminating to ensure we don't write incomplete and/or broken log messages to the log file.

### Alternate Designs
There are most likely lots of other ways to ensure the consistency of the log messages written to the log file.

### Benefits
Proper parsable log messages are sent to ETOS Client.

### Possible Drawbacks
We need to align the timeout with the termination time in Kubernetes

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
