### PR TITLE
Decrypt passwords if there is an encryption key available

### DIFF
--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -17,4 +17,5 @@
 #
 PyScaffold==3.2.3
 packageurl-python==0.9.1
+cryptography~=41.0
 etos_lib==3.2.2

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -27,6 +27,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires =
     PyScaffold==3.2.3
     packageurl-python==0.9.1
+    cryptography~=41.0
     etos_lib==3.2.2
 
 python_requires = >=3.4

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
@@ -34,20 +34,21 @@ class Executor:  # pylint:disable=too-few-public-methods
         self.etos = etos
         self.etos.config.set("build_urls", [])
 
-    @staticmethod
-    def __decrypt(password):
+    def __decrypt(self, password):
         """Decrypt a password using an encryption key.
 
         :param password: Password to decrypt.
-        :type password: str
+        :type password: str or dict
         :return: Decrypted password
         :rtype: str
         """
         key = os.getenv("ETOS_ENCRYPTION_KEY")
         if key is None:
+            self.logger.debug("No encryption key available, won't decrypt password")
             return password
         password_value = password.get("$decrypt", {}).get("value")
         if password_value is None:
+            self.logger.debug("No '$decrypt' JSONTas struct for password, won't decrypt password")
             return password
         return Fernet(key).decrypt(password_value).decode()
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
eiffel-community/etos#50

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Make sure we decrypt the password if there's an encryption key and the password is set.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I thought about using JSONTas similar to how we do it in ETR. But for the ESR it is quite straight-forward to get the password so I thought that would make the code easier to deal with.

### Benefits
<!-- What benefits will be realized by the change? -->
Encrypted passwords in JSONTas files!

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This solution assumes that if the encryption key is set, then the password is encrypted but that might now be the case always.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
