### PR TITLE
Update to version 4.0.0 of the ETOS library

### DIFF
--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,4 +18,4 @@
 PyScaffold==3.2.3
 packageurl-python==0.9.1
 cryptography~=41.0
-etos_lib==3.2.2
+etos_lib==4.0.0

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python==0.9.1
     cryptography~=41.0
-    etos_lib==3.2.2
+    etos_lib==4.0.0
 
 python_requires = >=3.4
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -27,11 +27,12 @@ from uuid import uuid4
 from eiffellib.events import EiffelActivityTriggeredEvent
 from etos_lib import ETOS
 from etos_lib.logging.logger import FORMAT_CONFIG
-from etos_suite_runner.lib.esr_parameters import ESRParameters
-from etos_suite_runner.lib.exceptions import EnvironmentProviderException
-from etos_suite_runner.lib.runner import SuiteRunner
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
+
+from .lib.esr_parameters import ESRParameters
+from .lib.exceptions import EnvironmentProviderException
+from .lib.runner import SuiteRunner
 
 # Remove spam from pika.
 logging.getLogger("pika").setLevel(logging.WARNING)
@@ -61,7 +62,7 @@ class ESR:  # pylint:disable=too-many-instance-attributes
             int(os.getenv("ESR_WAIT_FOR_ENVIRONMENT_TIMEOUT")),
         )
 
-    def _request_environment(self, ids: list[str]) -> tuple(str, str):
+    def _request_environment(self, ids: list[str]) -> tuple[str, str]:
         """Request an environment from the environment provider.
 
         :param ids: Generated suite runner IDs used to correlate environments and the suite

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ESR parameters module."""
-import os
 import json
 import logging
+import os
 from threading import Lock
 
-from packageurl import PackageURL
 from eiffellib.events import EiffelTestExecutionRecipeCollectionCreatedEvent
+from packageurl import PackageURL
+
 from .graphql import request_artifact_created
 
 
@@ -96,14 +97,12 @@ class ESRParameters:
                     self.__test_suite = batch
                 elif batch_uri is not None:
                     json_header = {"Accept": "application/json"}
-                    json_response = self.etos.http.wait_for_request(
+                    response = self.etos.http.get(
                         batch_uri,
                         headers=json_header,
                     )
-                    response = {}
-                    for response in json_response:
-                        break
-                    self.__test_suite = response
+                    response.raise_for_status()
+                    self.__test_suite = response.json()
         return self.__test_suite if self.__test_suite else []
 
     @property

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
@@ -19,7 +19,11 @@ import logging
 import os
 from threading import Lock
 
-from eiffellib.events import EiffelTestExecutionRecipeCollectionCreatedEvent
+from eiffellib.events import (
+    EiffelArtifactCreatedEvent,
+    EiffelTestExecutionRecipeCollectionCreatedEvent,
+)
+from etos_lib import ETOS
 from packageurl import PackageURL
 
 from .graphql import request_artifact_created
@@ -32,34 +36,32 @@ class ESRParameters:
     lock = Lock()
     __test_suite = None
 
-    def __init__(self, etos):
+    def __init__(self, etos: ETOS) -> None:
         """ESR parameters instance."""
         self.etos = etos
         self.issuer = {"name": "ETOS Suite Runner"}
         self.environment_status = {"status": "NOT_STARTED", "error": None}
 
-    def set_status(self, status, error):
+    def set_status(self, status: str, error: str) -> None:
         """Set environment provider status."""
         with self.lock:
             self.logger.debug("Setting environment status to %r, error %r", status, error)
             self.environment_status["status"] = status
             self.environment_status["error"] = error
 
-    def get_status(self):
+    def get_status(self) -> dict:
         """Get environment provider status.
 
         :return: Status dictionary for the environment provider.
-        :rtype: dict
         """
         with self.lock:
             return self.environment_status.copy()
 
     @property
-    def artifact_created(self):
+    def artifact_created(self) -> EiffelArtifactCreatedEvent:
         """Artifact under test.
 
         :return: Artifact created event.
-        :rtype: :obj:`EiffelArtifactCreatedEvent`
         """
         if self.etos.config.get("artifact_created") is None:
             artifact_created = request_artifact_created(self.etos, self.tercc)
@@ -67,11 +69,10 @@ class ESRParameters:
         return self.etos.config.get("artifact_created")
 
     @property
-    def tercc(self):
+    def tercc(self) -> EiffelTestExecutionRecipeCollectionCreatedEvent:
         """Test execution recipe collection created event from environment.
 
         :return: Test execution event.
-        :rtype: :obj:`EiffelTestExecutionRecipeCollectionCreatedEvent`
         """
         if self.etos.config.get("tercc") is None:
             tercc = EiffelTestExecutionRecipeCollectionCreatedEvent()
@@ -80,12 +81,8 @@ class ESRParameters:
         return self.etos.config.get("tercc")
 
     @property
-    def test_suite(self):
-        """Download and return test batches.
-
-        :return: Batches.
-        :rtype: list
-        """
+    def test_suite(self) -> list[dict]:
+        """Download and return test batches."""
         with self.lock:
             if self.__test_suite is None:
                 tercc = self.tercc.json
@@ -106,11 +103,10 @@ class ESRParameters:
         return self.__test_suite if self.__test_suite else []
 
     @property
-    def product(self):
+    def product(self) -> str:
         """Product name from artifact created event.
 
         :return: Product name.
-        :rtype: str
         """
         if self.etos.config.get("product") is None:
             identity = self.artifact_created["data"].get("identity")

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -19,8 +19,8 @@ from multiprocessing.pool import ThreadPool
 
 from etos_lib.logging.logger import FORMAT_CONFIG
 
-from .suite import TestSuite
 from .exceptions import EnvironmentProviderException
+from .suite import TestSuite
 
 
 class SuiteRunner:  # pylint:disable=too-few-public-methods
@@ -49,14 +49,10 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         :param task_id: Task ID to release.
         :type task_id: str
         """
-        wait_generator = self.etos.http.wait_for_request(
-            self.etos.debug.environment_provider,
-            params={"release": task_id},
-            timeout=60,
+        response = self.etos.http.get(
+            self.etos.debug.environment_provider, params={"release": task_id}, timeout=60
         )
-        for response in wait_generator:
-            if response:
-                break
+        response.raise_for_status()
 
     def start_suites_and_wait(self):
         """Get environments and start all test suites."""

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -356,7 +356,7 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
         )
         self.logger.info("Test suite finished.")
 
-    def results(self) -> tuple(str, str, str):
+    def results(self) -> tuple[str, str, str]:
         """Test results for this execution.
 
         :return: Verdict, conclusion and description.

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -17,11 +17,14 @@
 import logging
 import threading
 import time
+from typing import Iterator
 
 from eiffellib.events import EiffelTestSuiteStartedEvent
+from etos_lib import ETOS
 from etos_lib.logging.logger import FORMAT_CONFIG
 from requests.exceptions import HTTPError
 
+from .esr_parameters import ESRParameters
 from .exceptions import EnvironmentProviderException
 from .executor import Executor
 from .graphql import (
@@ -39,7 +42,7 @@ class SubSuite:
 
     released = False
 
-    def __init__(self, etos, environment, main_suite_id):
+    def __init__(self, etos: ETOS, environment: dict, main_suite_id: str) -> None:
         """Initialize a sub suite."""
         self.etos = etos
         self.environment = environment
@@ -50,12 +53,12 @@ class SubSuite:
         self.test_suite_finished = {}
 
     @property
-    def finished(self):
+    def finished(self) -> bool:
         """Whether or not this sub suite has finished."""
         return bool(self.test_suite_finished)
 
     @property
-    def started(self):
+    def started(self) -> bool:
         """Whether or not this sub suite has started."""
         if not bool(self.test_suite_started):
             for test_suite_started in request_test_suite_started(self.etos, self.main_suite_id):
@@ -67,7 +70,7 @@ class SubSuite:
                     break
         return bool(self.test_suite_started)
 
-    def request_finished_event(self):
+    def request_finished_event(self) -> None:
         """Request a test suite finished event for this sub suite."""
         # Prevent ER requests if we know we're not even started.
         if not self.started:
@@ -78,21 +81,19 @@ class SubSuite:
                 self.etos, self.test_suite_started["meta"]["id"]
             )
 
-    def outcome(self):
+    def outcome(self) -> dict:
         """Outcome of this sub suite.
 
         :return: Test suite outcome from the test suite finished event.
-        :rtype: dict
         """
         if self.finished:
             return self.test_suite_finished.get("data", {}).get("testSuiteOutcome", {})
         return {}
 
-    def start(self, identifier):
+    def start(self, identifier: str) -> None:
         """Start ETR for this sub suite.
 
         :param identifier: An identifier for logs in this sub suite.
-        :type identifier: str
         """
         FORMAT_CONFIG.identifier = identifier
         self.logger.info("Starting up the ETOS test runner", extra={"user_log": True})
@@ -113,7 +114,7 @@ class SubSuite:
         finally:
             self.release()
 
-    def release(self):
+    def release(self) -> None:
         """Release this sub suite."""
         self.logger.info(
             "Check in test environment %r", self.environment["id"], extra={"user_log": True}
@@ -143,7 +144,7 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
     __activity_triggered = None
     __activity_finished = None
 
-    def __init__(self, etos, params, suite):
+    def __init__(self, etos: ETOS, params: ESRParameters, suite: dict) -> None:
         """Initialize a TestSuite instance."""
         self.etos = etos
         self.params = params
@@ -153,7 +154,7 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
         self.sub_suites = []
 
     @property
-    def sub_suite_environments(self):
+    def sub_suite_environments(self) -> Iterator[dict]:
         """All sub suite environments from the environment provider.
 
         Each sub suite environment is an environment for the sub suites to execute in.
@@ -194,41 +195,35 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
             )
 
     @property
-    def all_finished(self):
+    def all_finished(self) -> bool:
         """Whether or not all sub suites are finished."""
         return all(sub_suite.finished for sub_suite in self.sub_suites)
 
-    def __environment_activity_triggered(self, test_suite_started_id):
+    def __environment_activity_triggered(self, test_suite_started_id: str) -> dict:
         """Activity triggered event from the environment provider.
 
         :param test_suite_started_id: The ID that the activity triggered links to.
-        :type test_suite_started_id: str
         :return: An activity triggered event dictionary.
-        :rtype: dict
         """
         if self.__activity_triggered is None:
             self.__activity_triggered = request_activity_triggered(self.etos, test_suite_started_id)
         return self.__activity_triggered
 
-    def __environment_activity_finished(self, activity_triggered_id):
+    def __environment_activity_finished(self, activity_triggered_id: str) -> dict:
         """Activity finished event from the environment provider.
 
         :param activity_triggered_id: The ID that the activity finished links to.
-        :type activity_triggered_id: str
         :return: An activity finished event dictionary.
-        :rtype: dict
         """
         if self.__activity_finished is None:
             self.__activity_finished = request_activity_finished(self.etos, activity_triggered_id)
         return self.__activity_finished
 
-    def _download_sub_suite(self, environment):
+    def _download_sub_suite(self, environment: dict) -> dict:
         """Download a sub suite from an EnvironmentDefined event.
 
         :param environment: Environment defined event to download from.
-        :type environment: dict
         :return: Downloaded sub suite information.
-        :rtype: dict
         """
         if environment["data"].get("uri") is None:
             return None
@@ -239,13 +234,11 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
         response.raise_for_status()
         return response.json()
 
-    def _announce(self, header, body):
+    def _announce(self, header: str, body: str) -> None:
         """Send an announcement over Eiffel.
 
         :param header: Header of the announcement.
-        :type header: str
         :param body: Body of the announcement.
-        :type body: str
         """
         self.etos.events.send_announcement_published(
             f"[ESR] {header}",
@@ -254,11 +247,10 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
             {"CONTEXT": self.etos.config.get("context")},
         )
 
-    def _send_test_suite_started(self):
+    def _send_test_suite_started(self) -> EiffelTestSuiteStartedEvent:
         """Send a test suite started event.
 
         :return: Test suite started event.
-        :rtype: :obj:`eiffellib.events.EiffelTestSuiteStartedEvent`
         """
         test_suite_started = EiffelTestSuiteStartedEvent()
 
@@ -279,7 +271,7 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
         }
         return self.etos.events.send(test_suite_started, links, data)
 
-    def start(self):
+    def start(self) -> None:
         """Send test suite started, trigger and wait for all sub suites to start."""
         self._announce("Starting tests", f"Starting up sub suites for '{self.suite.get('name')}'")
 
@@ -338,7 +330,7 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
             extra={"user_log": True},
         )
 
-    def release_all(self):
+    def release_all(self) -> None:
         """Release all, unreleased, sub suites."""
         self.logger.info("Releasing all sub suite environments")
         for sub_suite in self.sub_suites:
@@ -346,15 +338,12 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
                 sub_suite.release()
         self.logger.info("All sub suite environments are released")
 
-    def finish(self, verdict, conclusion, description):
+    def finish(self, verdict: str, conclusion: str, description: str) -> None:
         """Send test suite finished for this test suite.
 
         :param verdict: Verdict of the execution.
-        :type verdict: str
         :param conclusion: Conclusion taken on the results.
-        :type conclusion: str
         :param description: Description of the verdict and conclusion.
-        :type description: str
         """
         self.etos.events.send_test_suite_finished(
             self.test_suite_started,
@@ -367,11 +356,10 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
         )
         self.logger.info("Test suite finished.")
 
-    def results(self):
+    def results(self) -> tuple(str, str, str):
         """Test results for this execution.
 
         :return: Verdict, conclusion and description.
-        :rtype: tuple
         """
         verdict = "INCONCLUSIVE"
         conclusion = "SUCCESSFUL"


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Updated to make sure that the ESR is more sane when trying to start up ETR instances. Instead of us implementing our own wait_for, the etos library will now use built-in tools that make this better.
I also ran isort this time around, so a few imports may have moved around.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None

### Benefits
<!-- What benefits will be realized by the change? -->
We fail when there's no possibility of success and hopefully get better failure messages.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
This change is quite big, even if it looks small. We are changing a core behavior in the innards of ETOS which may cause weird bugs. I assume that we'll find bugs when testing this change.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
