### PR TITLE
Send EiffelActivityCanceledEvent from graceful_exit

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -22,7 +22,7 @@ import threading
 import traceback
 from uuid import uuid4
 
-from eiffellib.events import EiffelActivityTriggeredEvent
+from eiffellib.events import EiffelActivityTriggeredEvent, EiffelActivityCanceledEvent
 from environment_provider.environment_provider import EnvironmentProvider
 from environment_provider_api.backend.environment import release_full_environment
 from etos_lib import ETOS
@@ -216,4 +216,6 @@ class ESR:  # pylint:disable=too-many-instance-attributes
     def graceful_exit(self, *_) -> None:
         """Attempt to gracefully exit the running job."""
         self.logger.info("Kill command received - Attempting to shut down all processes.")
+        triggered: EiffelActivityCanceledEvent = EiffelActivityCanceledEvent()
+        self.etos.events.send_activity_canceled(triggered)
         raise RuntimeError("Terminate command received - Shutting down.")


### PR DESCRIPTION
### Applicable Issues
- [Abort running suites using DELETE request](https://github.com/eiffel-community/etos/issues/209)

### Description of the Change

This change is expected to let etosctl break the "Wait for ETOS to finish" loop when a testrun is aborted.

### Alternate Designs

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andreimu@axis.com