### PR TITLE
Updates for etos-environment-provider 4.0.0

### DIFF
--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
     etos_lib==4.0.0
-    etos_environment_provider~=3.2
+    etos_environment_provider~=4.0
 
 python_requires = >=3.4
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 
 from eiffellib.events import EiffelActivityTriggeredEvent
 from environment_provider.environment_provider import EnvironmentProvider
-from environment_provider_api.backend.environment import release_full_environment
+from environment_provider.environment import release_full_environment
 from etos_lib import ETOS
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -17,7 +17,7 @@
 import logging
 from multiprocessing.pool import ThreadPool
 
-from environment_provider_api.backend.environment import release_full_environment
+from environment_provider.environment import release_full_environment
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -21,7 +21,7 @@ from typing import Iterator
 
 from eiffellib.events import EiffelTestSuiteStartedEvent
 from environment_provider.lib.registry import ProviderRegistry
-from environment_provider_api.backend.environment import release_environment
+from environment_provider.environment import release_environment
 from etos_lib import ETOS
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/227

### Description of the Change

There have been some namespace changes in etos-environment-provider library. This change makes etos-suite-runner compatible with them.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
