### PR TITLE
Add OpenTelemetry instrumentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
-FROM python:3.9.0-buster AS build
+FROM python:3.9-buster AS build
 
 COPY . /src
 WORKDIR /src/projects/etos_suite_runner
 RUN python3 setup.py bdist_wheel
 
-FROM python:3.9.0-slim-buster
+FROM python:3.9-slim-buster
 
 COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
 # hadolint ignore=DL3013
-RUN pip install --no-cache-dir /tmp/*.whl && groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
+RUN apt-get update && \
+    apt-get install -y gcc libc-dev --no-install-recommends && \
+    pip install --no-cache-dir /tmp/*.whl && \
+    apt-get purge -y --auto-remove gcc libc-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
+
 USER etos
 
 LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-suite-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,6 @@ FROM python:3.9-slim-buster
 
 COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
 # hadolint ignore=DL3013
-# hadolint ignore=DL3008
-#RUN apt-get update && \
-#    apt-get install -y gcc libc-dev --no-install-recommends && \
-#    pip install --no-cache-dir /tmp/*.whl && \
-#    apt-get purge -y --auto-remove gcc libc-dev && \
-#    rm -rf /var/lib/apt/lists/* && \
-#    groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
 RUN pip install --no-cache-dir /tmp/*.whl && groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
 
 USER etos

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN python3 setup.py bdist_wheel
 FROM python:3.9-slim-buster
 
 COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
+# hadolint ignore=DL3008
 # hadolint ignore=DL3013
 RUN apt-get update && \
     apt-get install -y gcc libc-dev --no-install-recommends && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,15 @@ RUN python3 setup.py bdist_wheel
 FROM python:3.9-slim-buster
 
 COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
-# hadolint ignore=DL3008
 # hadolint ignore=DL3013
-RUN apt-get update && \
-    apt-get install -y gcc libc-dev --no-install-recommends && \
-    pip install --no-cache-dir /tmp/*.whl && \
-    apt-get purge -y --auto-remove gcc libc-dev && \
-    rm -rf /var/lib/apt/lists/* && \
-    groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
+# hadolint ignore=DL3008
+#RUN apt-get update && \
+#    apt-get install -y gcc libc-dev --no-install-recommends && \
+#    pip install --no-cache-dir /tmp/*.whl && \
+#    apt-get purge -y --auto-remove gcc libc-dev && \
+#    rm -rf /var/lib/apt/lists/* && \
+#    groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
+RUN pip install --no-cache-dir /tmp/*.whl && groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
 
 USER etos
 

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -19,10 +19,14 @@ PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
 <<<<<<< HEAD
+<<<<<<< HEAD
 etos_lib==4.0.0
 etos_environment_provider~=4.1
 =======
 etos_lib==4.1.1
+=======
+etos_lib==4.2.0
+>>>>>>> 11b187c (Code review changes)
 etos_environment_provider~=4.2
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,17 +18,8 @@
 PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
-<<<<<<< HEAD
-<<<<<<< HEAD
-etos_lib==4.0.0
-etos_environment_provider~=4.1
-=======
-etos_lib==4.1.1
-=======
 etos_lib==4.2.0
->>>>>>> 11b187c (Code review changes)
 etos_environment_provider~=4.2
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21
->>>>>>> e187c17 (Add OpenTelemetry instrumentation)

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,5 +18,13 @@
 PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
+<<<<<<< HEAD
 etos_lib==4.0.0
 etos_environment_provider~=4.1
+=======
+etos_lib==4.1.1
+#etos_environment_provider~=3.2
+opentelemetry-api~=1.21
+opentelemetry-exporter-otlp~=1.21
+opentelemetry-sdk~=1.21
+>>>>>>> e187c17 (Add OpenTelemetry instrumentation)

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -23,7 +23,7 @@ etos_lib==4.0.0
 etos_environment_provider~=4.1
 =======
 etos_lib==4.1.1
-#etos_environment_provider~=3.2
+etos_environment_provider~=4.2
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    #etos_lib==4.1.1
-    #etos_environment_provider~=4.0
+    etos_lib==4.2.0
+    etos_environment_provider~=4.2
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.1.1
+    #etos_lib==4.1.1
     #etos_environment_provider~=4.0
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,11 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.0.0
-    etos_environment_provider~=4.1
+    etos_lib==4.1.1
+    #etos_environment_provider~=4.0
+    opentelemetry-api~=1.21
+    opentelemetry-exporter-otlp~=1.21
+    opentelemetry-sdk~=1.21
 
 python_requires = >=3.4
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
@@ -42,7 +42,7 @@ setup_logging("ETOS Suite Runner", VERSION, ENVIRONMENT)
 LOGGER = logging.getLogger(__name__)
 
 # Setting OTEL_COLLECTOR_HOST will override the default OTEL collector endpoint.
-# This is needed when using the centralized cluster-level OTEL collector instead of sidecar collector.
+# This is needed when using the cluster-level OTEL collector instead of sidecar collector.
 if os.getenv("OTEL_COLLECTOR_HOST"):
     os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = os.getenv("OTEL_COLLECTOR_HOST")
     LOGGER.info("Using OTEL collector: %s", os.getenv("OTEL_COLLECTOR_HOST"))

--- a/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
@@ -50,7 +50,11 @@ if os.getenv("OTEL_COLLECTOR_HOST"):
 if os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"):
     PROVIDER = TracerProvider(
         resource=Resource.create(
-            {SERVICE_NAME: "etos-suite-runner", SERVICE_VERSION: VERSION, SERVICE_NAMESPACE: ENVIRONMENT}
+            {
+                SERVICE_NAME: "etos-suite-runner",
+                SERVICE_VERSION: VERSION,
+                SERVICE_NAMESPACE: ENVIRONMENT,
+            }
         )
     )
     EXPORTER = OTLPSpanExporter()

--- a/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
@@ -47,9 +47,10 @@ LOGGER = logging.getLogger(__name__)
 if os.getenv("OTEL_COLLECTOR_HOST"):
     os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = os.getenv("OTEL_COLLECTOR_HOST")
 else:
-    LOGGER.debug("Environment variable OTEL_EXPORTER_OTLP_TRACES_ENDPOINT not used.")
-    LOGGER.debug("To specify an OpenTelemetry collector host use OTEL_COLLECTOR_HOST.")
-    del os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]
+    if "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" in os.environ:
+        LOGGER.debug("Environment variable OTEL_EXPORTER_OTLP_TRACES_ENDPOINT not used.")
+        LOGGER.debug("To specify an OpenTelemetry collector host use OTEL_COLLECTOR_HOST.")
+        del os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"]
 
 if os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"):
     LOGGER.info(

--- a/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
@@ -14,8 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS suite runner module."""
+import logging
 import os
 from importlib.metadata import PackageNotFoundError, version
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_NAMESPACE, SERVICE_VERSION, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from etos_lib.logging.logger import setup_logging
 
@@ -30,3 +37,25 @@ DEV = os.getenv("DEV", "false").lower() == "true"
 ENVIRONMENT = "development" if DEV else "production"
 os.environ["ENVIRONMENT_PROVIDER_DISABLE_LOGGING"] = "true"
 setup_logging("ETOS Suite Runner", VERSION, ENVIRONMENT)
+
+
+LOGGER = logging.getLogger(__name__)
+
+# Setting OTEL_COLLECTOR_HOST will override the default OTEL collector endpoint.
+# This is needed when using the centralized cluster-level OTEL collector instead of sidecar collector.
+if os.getenv("OTEL_COLLECTOR_HOST"):
+    os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = os.getenv("OTEL_COLLECTOR_HOST")
+    LOGGER.info("Using OTEL collector: %s", os.getenv("OTEL_COLLECTOR_HOST"))
+
+if os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"):
+    PROVIDER = TracerProvider(
+        resource=Resource.create(
+            {SERVICE_NAME: "etos-suite-runner", SERVICE_VERSION: VERSION, SERVICE_NAMESPACE: ENVIRONMENT}
+        )
+    )
+    EXPORTER = OTLPSpanExporter()
+    PROCESSOR = BatchSpanProcessor(EXPORTER)
+    PROVIDER.add_span_processor(PROCESSOR)
+    trace.set_tracer_provider(PROVIDER)
+else:
+    LOGGER.info("Suite runner OTEL_EXPORTER_OTLP_TRACES_ENDPOINT not set!")

--- a/projects/etos_suite_runner/src/etos_suite_runner/__main__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__main__.py
@@ -39,9 +39,11 @@ def main():
         esr.etos.publisher.stop()
     LOGGER.info("ESR Finished Executing.", extra={"user_log": True})
 
+
 def run():
     """Entry point for console_scripts."""
     main()
+
 
 if __name__ == "__main__":
     run()

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -41,6 +41,7 @@ logging.getLogger("pika").setLevel(logging.WARNING)
 
 SUBSUITE_CONTEXT = None
 
+
 class ESR:  # pylint:disable=too-many-instance-attributes
     """Suite runner for ETOS main program.
 
@@ -78,7 +79,7 @@ class ESR:  # pylint:disable=too-many-instance-attributes
             try:
                 provider = EnvironmentProvider(self.params.tercc.meta.event_id, ids, copy=False)
                 result = provider.run()
-            except Exception as exc:
+            except Exception:
                 self.params.set_status("FAILURE", "Failed to run environment provider")
                 self.logger.error(
                     "Environment provider has failed in creating an environment for test.",
@@ -107,7 +108,7 @@ class ESR:  # pylint:disable=too-many-instance-attributes
         jsontas = JsonTas()
         span_name = "release_full_environment"
         suite_context = get_current_context()
-        with self.otel_tracer.start_as_current_span(span_name, context=suite_context) as span:
+        with self.otel_tracer.start_as_current_span(span_name, context=suite_context):
             status, message = release_full_environment(
                 etos=self.etos, jsontas=jsontas, suite_id=self.params.tercc.meta.event_id
             )

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 # -*- coding: utf-8 -*-
 """ETOS suite runner module."""
-import json
 import logging
 import os
 import signal

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -27,7 +27,6 @@ from environment_provider.environment_provider import EnvironmentProvider
 from environment_provider.environment import release_full_environment
 from etos_lib import ETOS
 from etos_lib.logging.logger import FORMAT_CONFIG
-from etos_lib.opentelemetry.semconv import Attributes as SemConvAttributes
 from jsontas.jsontas import JsonTas
 import opentelemetry
 
@@ -74,8 +73,10 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         span_name = "request_environment"
         suite_context = get_current_context()
         with self.otel_tracer.start_as_current_span(
-            span_name, context=suite_context, kind=opentelemetry.trace.SpanKind.CLIENT,
-        ) as span:
+            span_name,
+            context=suite_context,
+            kind=opentelemetry.trace.SpanKind.CLIENT,
+        ):
             try:
                 provider = EnvironmentProvider(self.params.tercc.meta.event_id, ids, copy=False)
                 result = provider.run()
@@ -111,7 +112,9 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         span_name = "release_full_environment"
         suite_context = get_current_context()
         with self.otel_tracer.start_as_current_span(
-            span_name, context=suite_context, kind=opentelemetry.trace.SpanKind.CLIENT,
+            span_name,
+            context=suite_context,
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             status, message = release_full_environment(
                 etos=self.etos, jsontas=jsontas, suite_id=self.params.tercc.meta.event_id

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
@@ -26,7 +26,6 @@ from requests.auth import HTTPBasicAuth, HTTPDigestAuth
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
 
-from ..otel_tracing import get_current_context
 
 class TestStartException(Exception):
     """Exception when starting tests."""
@@ -94,7 +93,7 @@ class Executor:  # pylint:disable=too-few-public-methods
         method = getattr(self.etos.http, request.pop("method").lower())
         span_name = "start_execution_space"
         with self.tracer.start_as_current_span(span_name) as span:
-            span.set_attribute("executor_id", executor['id'])
+            span.set_attribute("executor_id", executor["id"])
             span.set_attribute("request", dumps(request, indent=4))
             try:
                 response = method(**request)

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
@@ -96,7 +96,9 @@ class Executor(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
         method = getattr(self.etos.http, request.pop("method").lower())
         span_name = "start_execution_space"
         with self.tracer.start_as_current_span(span_name, kind=trace.SpanKind.CLIENT) as span:
-            span.set_attribute(SemConvAttributes.EXECUTOR_ID, executor["id"])
+            span.set_attribute(
+                SemConvAttributes.EXECUTOR_ID, executor["id"] if "id" in executor else ""
+            )
             span.set_attribute("http.request.body", dumps(request))
             try:
                 response = method(**request)

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
@@ -29,6 +29,7 @@ from requests.exceptions import HTTPError
 
 from .otel_tracing import OpenTelemetryBase
 
+
 class TestStartException(Exception):
     """Exception when starting tests."""
 
@@ -94,11 +95,9 @@ class Executor(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
             request["auth"] = self.__auth(**request["auth"])
         method = getattr(self.etos.http, request.pop("method").lower())
         span_name = "start_execution_space"
-        with self.tracer.start_as_current_span(
-            span_name, kind=trace.SpanKind.CLIENT
-        ) as span:
+        with self.tracer.start_as_current_span(span_name, kind=trace.SpanKind.CLIENT) as span:
             span.set_attribute(SemConvAttributes.EXECUTOR_ID, executor["id"])
-            span.set_attribute("http.request.body", dumps(request, indent=4))
+            span.set_attribute("http.request.body", dumps(request))
             try:
                 response = method(**request)
                 response.raise_for_status()

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/otel_tracing.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/otel_tracing.py
@@ -30,6 +30,7 @@ LOGGER = logging.getLogger(__name__)
 class OpenTelemetryBase:
     """Base functionality for OpenTelemetry data collection."""
 
+    # pylint: disable=too-few-public-methods
     @staticmethod
     def _record_exception(exc) -> None:
         """Record the given exception to the current OpenTelemetry span."""
@@ -46,9 +47,9 @@ class EnvVarContextGetter(Getter):
         """Get value using the given carrier variable and key."""
         value = os.getenv(carrier)
         if value is not None:
-            pairs = value.split(',')
+            pairs = value.split(",")
             for pair in pairs:
-                k, v = pair.split('=', 1)
+                k, v = pair.split("=", 1)
                 if k == key:
                     return [v]
         return []
@@ -57,8 +58,9 @@ class EnvVarContextGetter(Getter):
         """Get keys of the given carrier variable."""
         value = os.getenv(carrier)
         if value is not None:
-            return [pair.split('=')[0] for pair in value.split(',') if '=' in pair]
+            return [pair.split("=")[0] for pair in value.split(",") if "=" in pair]
         return []
+
 
 def get_current_context() -> opentelemetry.context.context.Context:
     """Get current context propagated via environment variable OTEL_CONTEXT."""

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -20,8 +20,10 @@ from multiprocessing.pool import ThreadPool
 from environment_provider.environment import release_full_environment
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas
+import opentelemetry
 
 from .exceptions import EnvironmentProviderException
+from ..otel_tracing import get_current_context
 from .suite import TestSuite
 
 
@@ -44,6 +46,8 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         """
         self.params = params
         self.etos = etos
+        self.otel_tracer = opentelemetry.trace.get_tracer(__name__)
+        self.otel_suite_context = get_current_context()
 
     def _release_environment(self):
         """Release an environment from the environment provider."""
@@ -51,17 +55,19 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         # Passing variables as keyword argument to make it easier to transition to a function where
         # jsontas is not required.
         jsontas = JsonTas()
-        status, message = release_full_environment(
-            etos=self.etos, jsontas=jsontas, suite_id=self.params.tercc.meta.event_id
-        )
-        if not status:
-            self.logger.error(message)
+        span_name = "release_full_environment"
+        with self.otel_tracer.start_as_current_span(span_name, context=self.otel_suite_context):
+            status, message = release_full_environment(
+                etos=self.etos, jsontas=jsontas, suite_id=self.params.tercc.meta.event_id
+            )
+            if not status:
+                self.logger.error(message)
 
     def start_suites_and_wait(self):
         """Get environments and start all test suites."""
         try:
             test_suites = [
-                TestSuite(self.etos, self.params, suite) for suite in self.params.test_suite
+                TestSuite(self.etos, self.params, suite, otel_context=self.otel_suite_context) for suite in self.params.test_suite
             ]
             with ThreadPool() as pool:
                 pool.map(self.run, test_suites)

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -17,8 +17,6 @@
 import logging
 from multiprocessing.pool import ThreadPool
 
-import opentelemetry.trace
-
 from environment_provider.environment import release_full_environment
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas
@@ -59,7 +57,9 @@ class SuiteRunner(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
         jsontas = JsonTas()
         span_name = "release_full_environment"
         with self.otel_tracer.start_as_current_span(
-            span_name, context=self.otel_suite_context, kind=opentelemetry.trace.SpanKind.CLIENT,
+            span_name,
+            context=self.otel_suite_context,
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             status, message = release_full_environment(
                 etos=self.etos, jsontas=jsontas, suite_id=self.params.tercc.meta.event_id

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -67,7 +67,8 @@ class SuiteRunner:  # pylint:disable=too-few-public-methods
         """Get environments and start all test suites."""
         try:
             test_suites = [
-                TestSuite(self.etos, self.params, suite, otel_context=self.otel_suite_context) for suite in self.params.test_suite
+                TestSuite(self.etos, self.params, suite, otel_context=self.otel_suite_context)
+                for suite in self.params.test_suite
             ]
             with ThreadPool() as pool:
                 pool.map(self.run, test_suites)

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -21,7 +21,6 @@ import time
 from typing import Iterator
 
 from eiffellib.events import EiffelTestSuiteStartedEvent
-import opentelemetry.trace
 from environment_provider.lib.registry import ProviderRegistry
 from environment_provider.environment import release_environment
 from etos_lib import ETOS
@@ -108,7 +107,9 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
         # This is because the subsuite is running in a separate thread.
         span_name = "execute_testrunner"
         with self.otel_tracer.start_as_current_span(
-            span_name, context=otel_context, kind=opentelemetry.trace.SpanKind.CLIENT,
+            span_name,
+            context=otel_context,
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ) as span:
             span.set_attribute(SemConvAttributes.SUBSUITE_ID, identifier)
             FORMAT_CONFIG.identifier = identifier
@@ -153,7 +154,8 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
 
         span_name = "release_environment"
         with self.otel_tracer.start_as_current_span(
-            span_name, kind=opentelemetry.trace.SpanKind.CLIENT,
+            span_name,
+            kind=opentelemetry.trace.SpanKind.CLIENT,
         ) as span:
             failure = release_environment(
                 etos=self.etos,
@@ -162,7 +164,7 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
                 sub_suite=self.environment,
             )
             span.set_attribute(SemConvAttributes.TESTRUN_ID, testrun_id)
-            span.set_attribute(SemConvAttributes.ENVIRONMENT, json.dumps(self.environment, indent=4))
+            span.set_attribute(SemConvAttributes.ENVIRONMENT, json.dumps(self.environment))
             if failure is not None:
                 self.logger.exception(
                     "Failed to check in %r", self.environment["id"], extra={"user_log": True}

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -175,11 +175,12 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
     __activity_triggered = None
     __activity_finished = None
 
-    def __init__(self,
+    def __init__(
+        self,
         etos: ETOS,
         params: ESRParameters,
         suite: dict,
-        otel_context: opentelemetry.context.context.Context = None
+        otel_context: opentelemetry.context.context.Context = None,
     ) -> None:
         """Initialize a TestSuite instance."""
         self.etos = etos

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -101,7 +101,8 @@ class SubSuite:  # pylint:disable=too-many-instance-attributes
 
         :param identifier: An identifier for logs in this sub suite.
         """
-        # OpenTelemetry context needs to be retrieved here, since the subsuite is running in a separate process
+        # OpenTelemetry context needs to be retrieved here:
+        # the subsuite is running in a separate process
         span_name = "execute_testrunner"
         with self.otel_tracer.start_as_current_span(span_name, context=otel_context) as span:
             span.set_attribute("subsuite_id", identifier)
@@ -175,10 +176,10 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
     __activity_finished = None
 
     def __init__(self,
-                 etos: ETOS,
-                 params: ESRParameters,
-                 suite: dict,
-                 otel_context: opentelemetry.context.context.Context = None
+        etos: ETOS,
+        params: ESRParameters,
+        suite: dict,
+        otel_context: opentelemetry.context.context.Context = None
     ) -> None:
         """Initialize a TestSuite instance."""
         self.etos = etos

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -39,7 +39,6 @@ from .graphql import (
     request_test_suite_started,
 )
 from .log_filter import DuplicateFilter
-from ..otel_tracing import get_current_context
 
 
 class SubSuite:  # pylint:disable=too-many-instance-attributes
@@ -149,7 +148,10 @@ class SubSuite:  # pylint:disable=too-many-instance-attributes
         span_name = "release_environment"
         with self.otel_tracer.start_as_current_span(span_name) as span:
             failure = release_environment(
-                etos=self.etos, jsontas=jsontas, provider_registry=registry, sub_suite=self.environment
+                etos=self.etos,
+                jsontas=jsontas,
+                provider_registry=registry,
+                sub_suite=self.environment,
             )
             span.set_attribute("testrun_id", testrun_id)
             span.set_attribute("failure", str(failure))
@@ -172,7 +174,12 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
     __activity_triggered = None
     __activity_finished = None
 
-    def __init__(self, etos: ETOS, params: ESRParameters, suite: dict, otel_context: opentelemetry.context.context.Context = None) -> None:
+    def __init__(self,
+                 etos: ETOS,
+                 params: ESRParameters,
+                 suite: dict,
+                 otel_context: opentelemetry.context.context.Context = None
+    ) -> None:
         """Initialize a TestSuite instance."""
         self.etos = etos
         self.params = params
@@ -340,7 +347,8 @@ class TestSuite:  # pylint:disable=too-many-instance-attributes
                 )
                 self.sub_suites.append(sub_suite)
                 thread = threading.Thread(
-                    target=sub_suite.start, args=(self.params.tercc.meta.event_id, self.otel_context)
+                    target=sub_suite.start,
+                    args=(self.params.tercc.meta.event_id, self.otel_context),
                 )
                 threads.append(thread)
                 thread.start()

--- a/projects/etos_suite_runner/src/etos_suite_runner/otel_tracing.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/otel_tracing.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # -*- coding: utf-8 -*-
+"""OpenTelemetry-related code."""
 import logging
 import os
 import opentelemetry

--- a/projects/etos_suite_runner/src/etos_suite_runner/otel_tracing.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/otel_tracing.py
@@ -21,6 +21,7 @@ import opentelemetry
 
 LOGGER = logging.getLogger(__name__)
 
+
 def get_current_context() -> opentelemetry.context.context.Context:
     """Get current context (propagated via environment variable OTEL_CONTEXT)."""
     carrier = {}


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/228
- Depends On https://github.com/eiffel-community/etos-library/pull/27

### Description of the Change

This change adds OpenTelemetry instrumentation to etos-suite-runner.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com