### PR TITLE
Subsuite status FAILED based on verdict/outcome

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -47,7 +47,8 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
     """Handle test results and tracking of a single sub suite."""
 
     released = False
-    failed = False
+    _failed = False
+    _failed_flag_set = False
 
     def __init__(self, etos: ETOS, environment: dict, main_suite_id: str) -> None:
         """Initialize a sub suite."""
@@ -59,6 +60,21 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
         self.otel_tracer = opentelemetry.trace.get_tracer(__name__)
         self.test_suite_started = {}
         self.test_suite_finished = {}
+
+    @property
+    def failed(self) -> bool:
+        """Property indicating whether the sub-suite has had failures."""
+        if self._failed_flag_set:
+            return self._failed
+        verdict = self.outcome().get("verdict")
+        conclusion = self.outcome().get("conclusion")
+        return "FAILED" in (verdict, conclusion)
+
+    @failed.setter
+    def failed(self, value: bool) -> None:
+        """Setter for the 'failed' property."""
+        self._failed = value
+        self._failed_flag_set = True
 
     @property
     def finished(self) -> bool:


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/234

### Description of the Change

This change modifies the behavior of the "failed" instance variable. If not set explicitly, it will return true if either verdict or conclusion of the suite is set to FAILED.

Without this change Suite Runner does not handle a case if a sub suite verdict and conclusion are both set to FAILED. In that case the verdict description is: "No description received from ESR or ETR." With this change it is set to "{len(failed)} sub suites failed to start"

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com
