### PR TITLE
Add OpenTelemetry trace id to logstash entries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir /tmp/*.whl && groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
 
-RUN pip list
-
 USER etos
 
 LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-suite-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
 # hadolint ignore=DL3013
 RUN pip install --no-cache-dir /tmp/*.whl && groupadd -r etos && useradd -r -m -s /bin/false -g etos etos
 
+RUN pip list
+
 USER etos
 
 LABEL org.opencontainers.image.source=https://github.com/eiffel-community/etos-suite-runner

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,8 +18,8 @@
 PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
-etos_lib==4.2.0
-etos_environment_provider~=4.2
+etos_lib==4.3.0
+#etos_environment_provider~=4.2
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,8 +18,8 @@
 PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
-etos_lib==4.3.0
-etos_environment_provider~=4.3
+etos_lib==4.3.1
+etos_environment_provider~=4.4
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -19,7 +19,7 @@ PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
 etos_lib==4.3.0
-#etos_environment_provider~=4.2
+etos_environment_provider~=4.3
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -19,7 +19,7 @@ PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
 etos_lib==4.3.1
-etos_environment_provider~=4.4
+etos_environment_provider==4.4.1
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.3.0
-    etos_environment_provider~=4.3
+    #etos_lib==4.3.0
+    #etos_environment_provider~=4.3
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
     etos_lib==4.3.1
-    etos_environment_provider~=4.4
+    etos_environment_provider==4.4.1
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    #etos_lib==4.3.0
-    #etos_environment_provider~=4.3
+    etos_lib==4.3.0
+    etos_environment_provider~=4.3
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.3.0
-    etos_environment_provider~=4.3
+    #etos_lib==4.3.1
+    #etos_environment_provider~=4.3
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
     etos_lib==4.3.0
-    #etos_environment_provider~=4.2
+    etos_environment_provider~=4.3
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    #etos_lib==4.3.1
-    #etos_environment_provider~=4.3
+    etos_lib==4.3.1
+    etos_environment_provider~=4.4
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.2.0
-    etos_environment_provider~=4.2
+    etos_lib==4.3.0
+    #etos_environment_provider~=4.2
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -151,7 +151,12 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
             carrier = {}
             TraceContextTextMapPropagator().inject(carrier)
             threading.Thread(
-                target=self._request_environment, args=(ids.copy(), carrier,), daemon=True
+                target=self._request_environment,
+                args=(
+                    ids.copy(),
+                    carrier,
+                ),
+                daemon=True,
             ).start()
 
             self.etos.events.send_activity_started(triggered, {"CONTEXT": context})

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -67,9 +67,6 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
             int(os.getenv("ESR_WAIT_FOR_ENVIRONMENT_TIMEOUT")),
         )
 
-        self.otel_context = None
-        self.otel_context_token = None
-
     def __del__(self):
         """Destructor."""
         if self.otel_context_token is not None:
@@ -120,7 +117,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         :param otel_context_carrier: a dict carrying current OpenTelemetry context.
         """
         # OpenTelemetry contexts aren't propagated to threads automatically.
-        # For this reason otel_context needs to be restantiated due to
+        # For this reason otel_context needs to be reinstantiated due to
         # this method running in a separate thread.
         otel_context = TraceContextTextMapPropagator().extract(carrier=otel_context_carrier)
         otel_context_token = opentelemetry.context.attach(otel_context)

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -23,8 +23,6 @@ import traceback
 from uuid import uuid4
 
 from eiffellib.events import EiffelActivityTriggeredEvent
-import opentelemetry.context
-import opentelemetry.context.context
 from environment_provider.environment_provider import EnvironmentProvider
 from environment_provider.environment import release_full_environment
 from etos_lib import ETOS

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -29,6 +29,7 @@ from etos_lib import ETOS
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas
 import opentelemetry
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from .lib.esr_parameters import ESRParameters
 from .lib.exceptions import EnvironmentProviderException
@@ -52,6 +53,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         """Initialize ESR by creating a rabbitmq publisher."""
         self.logger = logging.getLogger("ESR")
         self.otel_tracer = opentelemetry.trace.get_tracer(__name__)
+        opentelemetry.context.attach(get_current_context())
         self.etos = ETOS("ETOS Suite Runner", os.getenv("SOURCE_HOST"), "ETOS Suite Runner")
         signal.signal(signal.SIGTERM, self.graceful_exit)
         self.params = ESRParameters(self.etos)
@@ -64,21 +66,23 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
             int(os.getenv("ESR_WAIT_FOR_ENVIRONMENT_TIMEOUT")),
         )
 
-    def _request_environment(self, ids: list[str]) -> None:
+    def _request_environment(self, ids: list[str], otel_context_carrier: dict) -> None:
         """Request an environment from the environment provider.
 
         :param ids: Generated suite runner IDs used to correlate environments and the suite
                     runners.
+        :param otel_context_carrier: a dict carrying current OpenTelemetry context.
         """
         span_name = "request_environment"
-        suite_context = get_current_context()
+        suite_context = TraceContextTextMapPropagator().extract(carrier=otel_context_carrier)
+        opentelemetry.context.attach(suite_context)
         with self.otel_tracer.start_as_current_span(
             span_name,
             context=suite_context,
             kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             try:
-                provider = EnvironmentProvider(self.params.tercc.meta.event_id, ids, copy=False)
+                provider = EnvironmentProvider(self.params.tercc.meta.event_id, ids)
                 result = provider.run()
             except Exception as exc:
                 self.params.set_status("FAILURE", "Failed to run environment provider")
@@ -144,8 +148,10 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         self.logger.info("Number of test suites to run: %d", len(ids), extra={"user_log": True})
         try:
             self.logger.info("Get test environment.")
+            carrier = {}
+            TraceContextTextMapPropagator().inject(carrier)
             threading.Thread(
-                target=self._request_environment, args=(ids.copy(),), daemon=True
+                target=self._request_environment, args=(ids.copy(), carrier,), daemon=True
             ).start()
 
             self.etos.events.send_activity_started(triggered, {"CONTEXT": context})

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -127,7 +127,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         otel_context = TraceContextTextMapPropagator().extract(carrier=otel_context_carrier)
         otel_context_token = opentelemetry.context.attach(otel_context)
         try:
-            self.__request_environment(ids, otel_context)
+            self.__request_environment(ids)
         finally:
             opentelemetry.context.detach(otel_context_token)
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -21,6 +21,7 @@ from environment_provider.environment import release_full_environment
 from etos_lib.logging.logger import FORMAT_CONFIG
 from jsontas.jsontas import JsonTas
 import opentelemetry
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from .exceptions import EnvironmentProviderException
 from .otel_tracing import get_current_context, OpenTelemetryBase
@@ -70,8 +71,10 @@ class SuiteRunner(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
     def start_suites_and_wait(self):
         """Get environments and start all test suites."""
         try:
+            otel_context_carrier = {}
+            TraceContextTextMapPropagator().inject(otel_context_carrier)
             test_suites = [
-                TestSuite(self.etos, self.params, suite, otel_context=self.otel_suite_context)
+                TestSuite(self.etos, self.params, suite, otel_context_carrier=otel_context_carrier)
                 for suite in self.params.test_suite
             ]
             with ThreadPool() as pool:

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -192,6 +192,7 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         etos: ETOS,
         params: ESRParameters,
         suite: dict,
+        # pylint: disable=dangerous-default-value
         otel_context_carrier: dict = {},
     ) -> None:
         """Initialize a TestSuite instance."""
@@ -202,7 +203,9 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         self.logger.addFilter(DuplicateFilter(self.logger))
         self.sub_suites = []
         self.otel_context_carrier = otel_context_carrier
-        self.otel_context = TraceContextTextMapPropagator().extract(carrier=self.otel_context_carrier)
+        self.otel_context = TraceContextTextMapPropagator().extract(
+            carrier=self.otel_context_carrier
+        )
         opentelemetry.context.attach(self.otel_context)
         TraceContextTextMapPropagator().inject(self.otel_context_carrier)
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -28,6 +28,7 @@ from etos_lib.logging.logger import FORMAT_CONFIG
 from etos_lib.opentelemetry.semconv import Attributes as SemConvAttributes
 from jsontas.jsontas import JsonTas
 import opentelemetry
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from .esr_parameters import ESRParameters
 from .exceptions import EnvironmentProviderException
@@ -98,17 +99,20 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
             return self.test_suite_finished.get("data", {}).get("testSuiteOutcome", {})
         return {}
 
-    def start(self, identifier: str, otel_context: opentelemetry.context.context.Context) -> None:
+    def start(self, identifier: str, otel_context_carrier: dict) -> None:
         """Start ETR for this sub suite.
 
         :param identifier: An identifier for logs in this sub suite.
+        :otel_context_carrier: a dict propagating OpenTelemetry context from the parent thread.
         """
         # OpenTelemetry context needs to be explicitly given here when creating this new span.
         # This is because the subsuite is running in a separate thread.
+        otel_context = TraceContextTextMapPropagator().extract(carrier=otel_context_carrier)
+        opentelemetry.context.attach(otel_context)
         span_name = "execute_testrunner"
         with self.otel_tracer.start_as_current_span(
             span_name,
-            context=otel_context,
+            #context=otel_context,
             kind=opentelemetry.trace.SpanKind.CLIENT,
         ) as span:
             span.set_attribute(SemConvAttributes.SUBSUITE_ID, identifier)
@@ -189,7 +193,7 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         etos: ETOS,
         params: ESRParameters,
         suite: dict,
-        otel_context: opentelemetry.context.context.Context = None,
+        otel_context_carrier: dict = {},
     ) -> None:
         """Initialize a TestSuite instance."""
         self.etos = etos
@@ -198,7 +202,10 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         self.logger = logging.getLogger(f"TestSuite - {self.suite.get('name')}")
         self.logger.addFilter(DuplicateFilter(self.logger))
         self.sub_suites = []
-        self.otel_context = otel_context
+        self.otel_context_carrier = otel_context_carrier
+        self.otel_context = TraceContextTextMapPropagator().extract(carrier=self.otel_context_carrier)
+        opentelemetry.context.attach(self.otel_context)
+        TraceContextTextMapPropagator().inject(self.otel_context_carrier)
 
     @property
     def sub_suite_environments(self) -> Iterator[dict]:
@@ -331,6 +338,8 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
 
     def start(self) -> None:
         """Send test suite started, trigger and wait for all sub suites to start."""
+        otel_context = TraceContextTextMapPropagator().extract(carrier=self.otel_context_carrier)
+        opentelemetry.context.attach(otel_context)
         self._announce("Starting tests", f"Starting up sub suites for '{self.suite.get('name')}'")
 
         self.test_suite_started = self._send_test_suite_started()
@@ -365,7 +374,7 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
                 self.sub_suites.append(sub_suite)
                 thread = threading.Thread(
                     target=sub_suite.start,
-                    args=(self.params.tercc.meta.event_id, self.otel_context),
+                    args=(self.params.tercc.meta.event_id, self.otel_context_carrier),
                 )
                 threads.append(thread)
                 thread.start()

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -99,7 +99,6 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
             return self.test_suite_finished.get("data", {}).get("testSuiteOutcome", {})
         return {}
 
-    
     def _start(self, identifier: str) -> None:
         """Start ETR for this sub suite.
 
@@ -213,7 +212,7 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         self.logger = logging.getLogger(f"TestSuite - {self.suite.get('name')}")
         self.logger.addFilter(DuplicateFilter(self.logger))
         self.sub_suites = []
-    
+
         self.otel_context_carrier = otel_context_carrier
         self.otel_context = TraceContextTextMapPropagator().extract(
             carrier=self.otel_context_carrier
@@ -353,7 +352,7 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
             "TERC": self.params.tercc.meta.event_id,
         }
         return self.etos.events.send(test_suite_started, links, data)
-    
+
     def _start(self):
         """Send test suite started, trigger and wait for all sub suites to start."""
         self._announce("Starting tests", f"Starting up sub suites for '{self.suite.get('name')}'")
@@ -420,7 +419,10 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         )
 
     def start(self) -> None:
-        """OpenTelemetry wrapper method for _start()."""
+        """Send test suite started, trigger and wait for all sub suites to start.
+
+        This is an OpenTelemetry wrapper method for _start().
+        """
         # OpenTelemetry contexts aren't automatically propagated to threads.
         # For this reason OpenTelemetry context needs to be reinstantiated here.
         otel_context = TraceContextTextMapPropagator().extract(carrier=self.otel_context_carrier)

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -18,7 +18,7 @@ import json
 import logging
 import threading
 import time
-from typing import Iterator
+from typing import Iterator, Union
 
 from eiffellib.events import EiffelTestSuiteStartedEvent
 from environment_provider.lib.registry import ProviderRegistry
@@ -202,8 +202,7 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         etos: ETOS,
         params: ESRParameters,
         suite: dict,
-        # pylint: disable=dangerous-default-value
-        otel_context_carrier: dict = {},
+        otel_context_carrier: Union[dict, None] = None,
     ) -> None:
         """Initialize a TestSuite instance."""
         self.etos = etos
@@ -212,6 +211,9 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         self.logger = logging.getLogger(f"TestSuite - {self.suite.get('name')}")
         self.logger.addFilter(DuplicateFilter(self.logger))
         self.sub_suites = []
+
+        if otel_context_carrier is None:
+            otel_context_carrier = {}
 
         self.otel_context_carrier = otel_context_carrier
         self.otel_context = TraceContextTextMapPropagator().extract(

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -112,7 +112,6 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
         span_name = "execute_testrunner"
         with self.otel_tracer.start_as_current_span(
             span_name,
-            #context=otel_context,
             kind=opentelemetry.trace.SpanKind.CLIENT,
         ) as span:
             span.set_attribute(SemConvAttributes.SUBSUITE_ID, identifier)


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/236

### Description of the Change

This change fixes OpenTelemetry context propagation among threads so that logstash entries receive the correct opentelemetry_trace_id value.

### Alternate Designs

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com