### PR TITLE
Update version of environment provider

### DIFF
--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -19,7 +19,7 @@ PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
 etos_lib==4.2.0
-etos_environment_provider~=4.2
+etos_environment_provider==4.4.0
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,7 +18,7 @@
 PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
-etos_lib==4.2.0
+etos_lib==4.3.0
 etos_environment_provider==4.4.0
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.2.0
+    etos_lib==4.3.0
     etos_environment_provider==4.4.0
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
     etos_lib==4.2.0
-    etos_environment_provider~=4.2
+    etos_environment_provider==4.4.0
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -78,7 +78,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
             kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
             try:
-                provider = EnvironmentProvider(self.params.tercc.meta.event_id, ids, copy=False)
+                provider = EnvironmentProvider(self.params.tercc.meta.event_id, ids)
                 result = provider.run()
             except Exception as exc:
                 self.params.set_status("FAILURE", "Failed to run environment provider")


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
N/A

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Update version. I also removed the range selection of version since it will work poorly with the way we have set up the suite runner CI.
When the suite runner receives a change it will build a new docker image and push it. This would mean that if we make a change in the suite runner first, build the docker image and then update the environment provider we will not receive the change in the environment provider until a new change has been made to the suite runner.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
Obviously we could add a workflow or something to this suite runner which picks up the new version of environment provider and rebuilds. The problem with this approach is that we would need to use the same tag on the image, which would make the docker image mutable. This is not something we want.
With this proposed change we could also have a similar workflow but that it updates the requirements.txt and setup.cfg on changes of the environment provider.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
This change requires us to always update the suite runner whenever we release new changes on the environment provider.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
