### PR TITLE
Migrate from Debian Buster to Bookworm base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.9-buster AS build
+FROM python:3.9-bookworm AS build
 
 COPY . /src
 WORKDIR /src/projects/etos_suite_runner
 RUN python3 setup.py bdist_wheel
 
-FROM python:3.9-slim-buster
+FROM python:3.9-slim-bookworm
 
 COPY --from=build /src/projects/etos_suite_runner/dist/*.whl /tmp
 # hadolint ignore=DL3013

--- a/Dockerfile.log_listener
+++ b/Dockerfile.log_listener
@@ -1,4 +1,4 @@
-FROM python:3.9.0-buster AS build
+FROM python:3.9.0-bookworm AS build
 
 COPY . /src
 WORKDIR /src/projects/log_listener

--- a/Dockerfile.log_listener
+++ b/Dockerfile.log_listener
@@ -1,10 +1,10 @@
-FROM python:3.9.0-bookworm AS build
+FROM python:3.9-bookworm AS build
 
 COPY . /src
 WORKDIR /src/projects/log_listener
 RUN python3 setup.py bdist_wheel
 
-FROM python:3.9.0-slim-buster
+FROM python:3.9-slim-bookworm
 
 COPY --from=build /src/projects/log_listener/dist/*.whl /tmp
 # hadolint ignore=DL3013


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/235

### Description of the Change

This change migrates ETOS Suite Runner and Log Listener to Python 3.9 docker image based on Debian Bookworm.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com