### PR TITLE
etos_lib 4.3.6, etos_environment_provider 5.0.2

### DIFF
--- a/projects/etos_suite_runner/requirements.txt
+++ b/projects/etos_suite_runner/requirements.txt
@@ -18,8 +18,8 @@
 PyScaffold==3.2.3
 packageurl-python~=0.11
 cryptography>=42.0.4,<43.0.0
-etos_lib==4.3.1
-etos_environment_provider==5.0.1
+etos_lib==4.3.6
+etos_environment_provider==5.0.2
 opentelemetry-api~=1.21
 opentelemetry-exporter-otlp~=1.21
 opentelemetry-sdk~=1.21

--- a/projects/etos_suite_runner/setup.cfg
+++ b/projects/etos_suite_runner/setup.cfg
@@ -28,8 +28,8 @@ install_requires =
     PyScaffold==3.2.3
     packageurl-python~=0.11
     cryptography>=42.0.4,<43.0.0
-    etos_lib==4.3.1
-    etos_environment_provider==5.0.1
+    etos_lib==4.3.6
+    etos_environment_provider==5.0.2
     opentelemetry-api~=1.21
     opentelemetry-exporter-otlp~=1.21
     opentelemetry-sdk~=1.21


### PR DESCRIPTION
### Applicable Issues

- https://github.com/eiffel-community/etos/issues/247

### Description of the Change

This change steps up the versions of etos_environment_provider and etos_lib which includes a fix for the mentioned issue.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com