### PR TITLE
Use subsuite conclusion for suite failure checks

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -48,7 +48,7 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
     """Handle test results and tracking of a single sub suite."""
 
     released = False
-    failed = False
+    test_start_exception_caught = False
 
     def __init__(self, etos: ETOS, environment: dict, main_suite_id: str) -> None:
         """Initialize a sub suite."""
@@ -78,6 +78,20 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
                     self.test_suite_started = test_suite_started
                     break
         return bool(self.test_suite_started)
+
+    @property
+    def failed(self) -> bool:
+        if self.test_start_exception_caught:
+            return True
+        try:
+            conclusion = self.outcome()["conclusion"]
+        except KeyError:
+            msg = f"Failed to get conclusion for {self.environment.get('name')}. Main suite verdict/conclusion may be incorrect!"
+            exc = RuntimeError(msg)
+            self.logger.error(msg)
+            self._record_exception(exc)
+            conclusion = ""
+        return conclusion != "SUCCESSFUL"
 
     def request_finished_event(self) -> None:
         """Request a test suite finished event for this sub suite."""
@@ -116,7 +130,7 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
             try:
                 executor.run_tests(self.environment)
             except TestStartException as exception:
-                self.failed = True
+                self.test_start_exception_caught = True
                 self.logger.error(
                     "Failed to start sub suite: %s", exception.error, extra={"user_log": True}
                 )

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -81,12 +81,16 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
 
     @property
     def failed(self) -> bool:
+        """Whether or not this sub suite has failed."""
         if self.test_start_exception_caught:
             return True
         try:
             conclusion = self.outcome()["conclusion"]
         except KeyError:
-            msg = f"Failed to get conclusion for {self.environment.get('name')}. Main suite verdict/conclusion may be incorrect!"
+            msg = (
+                f"Failed to get conclusion for {self.environment.get('name')}. "
+                "Main suite verdict/conclusion may be incorrect!"
+            )
             exc = RuntimeError(msg)
             self.logger.error(msg)
             self._record_exception(exc)


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/293

### Description of the Change
This change extends the logic of determining if a sub-suite has failed by also checking sub-suite conclusions.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com