### PR TITLE
Remove TERCC variable check for v1alpha+ ETOS

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -256,7 +256,10 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
     def verify_input() -> None:
         """Verify that the data input to ESR are correct."""
         assert os.getenv("SOURCE_HOST"), "SOURCE_HOST environment variable not provided."
-        assert os.getenv("TERCC"), "TERCC environment variable not provided."
+
+        if os.getenv("TESTRUN") is None:
+            # TERCC variable is set only in v0 ETOS, TESTRUN in v1 and onwards.
+            assert os.getenv("TERCC"), "TERCC environment variable not provided."
 
     def _send_tercc(self, testrun_id: str, iut_id: str) -> None:
         """Send tercc will publish the TERCC event for this testrun."""


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
This change modifies the verify_input() function to only check TERCC variable if TESTRUN variable is not set. This is needed to separate the verification of v0 and v1alpha+ logic.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com