### PR TITLE
Get environments from Kubernetes

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -110,7 +110,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
                             reason = condition.get("reason", "").lower()
                             if status == "false" and reason == "failed":
                                 failed.append(condition)
-                            if status == "false" and reason == "done":
+                            if status == "true" and reason == "done":
                                 success.append(condition)
                 if found and len(failed) > 0:
                     for condition in failed:
@@ -122,14 +122,13 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
                     )
                     break
                 if found and len(success) == len(requests):
-                    self.params.set_status(
-                        "SUCCESS", "Successfully created an environment for test"
-                    )
+                    self.params.set_status("SUCCESS", None)
                     self.logger.info(
                         "Environment provider has finished creating an environment for test.",
                         extra={"user_log": True},
                     )
                     break
+        self.logger.info("Environmentrequest finished")
 
     def __request_environment(self, ids: list[str]) -> None:
         """Request an environment from the environment provider.
@@ -175,6 +174,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
                     runners.
         :param otel_context_carrier: a dict carrying current OpenTelemetry context.
         """
+        FORMAT_CONFIG.identifier = self.params.testrun_id
         # OpenTelemetry contexts aren't propagated to threads automatically.
         # For this reason otel_context needs to be reinstantiated due to
         # this method running in a separate thread.

--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -183,7 +183,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         try:
             # TestRun identifier, correlates to the TERCC that should be sent when
             # running in the ETOS Kubernetes controller environment.
-            if os.getenv("IDENTIFIER") is not None:
+            if self.params.etos_controller:
                 self.__environment_request_status()
             else:
                 self.__request_environment(ids)
@@ -246,7 +246,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
             runner.start_suites_and_wait(suites)
         except EnvironmentProviderException as exc:
             # Not running as part of the ETOS Kubernetes controller environment
-            if os.getenv("IDENTIFIER") is None:
+            if not self.params.etos_controller:
                 self.logger.info("Release test environment.")
                 self._release_environment()
             self._record_exception(exc)
@@ -281,7 +281,7 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
             self.logger.info("ETOS suite runner is starting up", extra={"user_log": True})
             # TestRun identifier, correlates to the TERCC that should be sent when
             # running in the ETOS Kubernetes controller environment.
-            if os.getenv("IDENTIFIER") is not None:
+            if self.params.etos_controller:
                 # We are probably running in the ETOS Kubernetes controller environment
                 self.logger.info("Checking TERCC")
                 if request_tercc(self.etos, testrun_id) is None:

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
@@ -44,7 +44,7 @@ class ESRParameters:
         self.issuer = {"name": "ETOS Suite Runner"}
         self.environment_status = {"status": "NOT_STARTED", "error": None}
 
-    def set_status(self, status: str, error: str) -> None:
+    def set_status(self, status: str, error: Optional[str] = None) -> None:
         """Set environment provider status."""
         with self.lock:
             self.logger.debug("Setting environment status to %r, error %r", status, error)

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
@@ -59,6 +59,11 @@ class ESRParameters:
         with self.lock:
             return self.environment_status.copy()
 
+    @property
+    def etos_controller(self) -> bool:
+        """Whether or not the suite runneris running as a part of the ETOS controller."""
+        return os.getenv("IDENTIFIER") is not None
+
     def _get_id(
         self,
         config_key: str,
@@ -112,7 +117,7 @@ class ESRParameters:
         taken from the Environment requests to the environment provider, and are
         used to correlate the environments created with the main test suites.
         """
-        if os.getenv("IDENTIFIER") is None:
+        if not self.etos_controller:
             return [str(uuid4()) for _ in range(len(self.test_suite))]
         return [request.spec.id for request in self.environment_requests]
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/esr_parameters.py
@@ -61,7 +61,7 @@ class ESRParameters:
 
     @property
     def etos_controller(self) -> bool:
-        """Whether or not the suite runneris running as a part of the ETOS controller."""
+        """Whether or not the suite runner is running as a part of the ETOS controller."""
         return os.getenv("IDENTIFIER") is not None
 
     def _get_id(

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/executor.py
@@ -64,7 +64,7 @@ class Executor(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
             self.logger.debug("No encryption key available, won't decrypt password")
             return password
         password_value = password.get("$decrypt", {}).get("value")
-        if password_value is None:
+        if password_value is None or password_value == "":
             self.logger.debug("No '$decrypt' JSONTas struct for password, won't decrypt password")
             return password
         return Fernet(key).decrypt(password_value).decode()

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ETOS suite runner executor."""
-import os
 import logging
 from multiprocessing.pool import ThreadPool
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -90,7 +90,7 @@ class SuiteRunner(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
                 raise exc
         finally:
             # Not running as part of controller
-            if os.getenv("IDENTIFIER") is None:
+            if not self.params.etos_controller:
                 self.logger.info("Release the full test environment.")
                 self._release_environment()
 

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Iterator, Union
 
-from eiffellib.events import EiffelTestSuiteStartedEvent
+from eiffellib.events import EiffelTestSuiteStartedEvent, EiffelEnvironmentDefinedEvent
 from environment_provider.lib.registry import ProviderRegistry
 from environment_provider.environment import release_environment
 from etos_lib import ETOS
@@ -268,16 +268,11 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
         """Destructor."""
         opentelemetry.context.detach(self.otel_context_token)
 
-    @property
-    def sub_suite_environments(self) -> Iterator[dict]:
+    def _sub_suite_environments_from_eiffel(self) -> Iterator[dict]:
         """All sub suite environments from the environment provider.
 
         Each sub suite environment is an environment for the sub suites to execute in.
         """
-        self.logger.debug(
-            "Start collecting sub suite definitions (timeout=%ds).",
-            self.etos.config.get("WAIT_FOR_ENVIRONMENT_TIMEOUT"),
-        )
         environments = []
         timeout = time.time() + self.etos.config.get("WAIT_FOR_ENVIRONMENT_TIMEOUT")
         while time.time() < timeout:
@@ -300,7 +295,13 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
             ):
                 if environment["meta"]["id"] not in environments:
                     environments.append(environment["meta"]["id"])
-                    yield environment
+                    sub_suite_definition = self._download_sub_suite(environment)
+                    if sub_suite_definition is None:
+                        raise EnvironmentProviderException(
+                            "URL to sub suite is missing", self.etos.config.get("task_id")
+                        )
+                    sub_suite_definition["id"] = environment["meta"]["id"]
+                    yield sub_suite_definition
             if activity_finished is not None:
                 if activity_finished["data"]["activityOutcome"]["conclusion"] != "SUCCESSFUL":
                     exc = EnvironmentProviderException(
@@ -317,6 +318,67 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
             )
             self._record_exception(exc)
             raise exc
+
+    def _sub_suite_environments_from_kubernetes(self) -> Iterator[dict]:
+        """All sub suite environments from Kubernetes.
+
+        Each sub suite environment is an environment for the sub suites to execute in.
+        """
+        environments = []
+        timeout = time.time() + self.etos.config.get("WAIT_FOR_ENVIRONMENT_TIMEOUT")
+        while time.time() < timeout:
+            time.sleep(5)
+            for environment in self.params.environments:
+                if environment.spec.sub_suite_id in environments:
+                    continue
+
+                # Send eiffel event for the ETR.
+                event = EiffelEnvironmentDefinedEvent()
+                event.meta.event_id = environment.metadata.name
+                url = f"{os.getenv('ETOS_API')}/v1alpha/testrun/{environment.metadata.name}"
+                self.etos.events.send(
+                    event,
+                    {"CONTEXT": self.test_suite_started_id},
+                    {"name": environment.spec.name, "uri": url},
+                )
+
+                environments.append(environment.spec.sub_suite_id)
+                executor = environment.spec.executor
+                yield {
+                    "executor": executor,
+                    "id": environment.spec.sub_suite_id,
+                    "name": environment.spec.name,
+                }
+            status = self.params.get_status()
+            if status.get("status") == "FAILURE":
+                exc = EnvironmentProviderException(
+                    status.get("error"), self.etos.config.get("task_id")
+                )
+                self._record_exception(exc)
+                raise exc
+            if status.get("status") == "SUCCESS" and len(environments) > 0:
+                return
+        else:  # pylint:disable=useless-else-on-loop
+            exc = TimeoutError(
+                f"Timed out after {self.etos.config.get('WAIT_FOR_ENVIRONMENT_TIMEOUT')} seconds."
+            )
+            self._record_exception(exc)
+            raise exc
+
+    @property
+    def sub_suite_environments(self) -> Iterator[dict]:
+        """All sub suite environments from the environment provider.
+
+        Each sub suite environment is an environment for the sub suites to execute in.
+        """
+        self.logger.debug(
+            "Start collecting sub suite definitions (timeout=%ds).",
+            self.etos.config.get("WAIT_FOR_ENVIRONMENT_TIMEOUT"),
+        )
+        if os.getenv("IDENTIFIER") is not None:
+            yield from self._sub_suite_environments_from_kubernetes()
+        else:
+            yield from self._sub_suite_environments_from_eiffel()
 
     @property
     def all_finished(self) -> bool:
@@ -400,16 +462,10 @@ class TestSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribut
                 self.test_suite_started.meta.event_id,
                 extra={"user_log": True},
             )
-            for sub_suite_environment in self.sub_suite_environments:
+            for sub_suite_definition in self.sub_suite_environments:
                 self.logger.info(
                     "Environment received. Starting up a sub suite", extra={"user_log": True}
                 )
-                sub_suite_definition = self._download_sub_suite(sub_suite_environment)
-                if sub_suite_definition is None:
-                    raise EnvironmentProviderException(
-                        "URL to sub suite is missing", self.etos.config.get("task_id")
-                    )
-                sub_suite_definition["id"] = sub_suite_environment["meta"]["id"]
                 sub_suite = SubSuite(self.etos, sub_suite_definition, self.test_suite_started_id)
                 self.sub_suites.append(sub_suite)
                 thread = threading.Thread(


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
Preparatory change for: eiffel-community/etos#306

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
Update so that the ESR will get the sub suite definition from Kubernetes instead of Eiffel when running using the ETOS controller.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I would want the ETOS controller to pass in an environment to the ESR when it has been created, thus creating one ESR for each environment just to manage and keep track of the ETR execution. This would, however, be a bigger change and I want to fix the problems we are seeing where the environment provider complains about a missing activity triggered (which this change can enable a fix for) first.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
Another branch in the code, making the ESR a bit more complex.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
