### PR TITLE
Migrate container images to ghcr.io

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -16,13 +16,17 @@ jobs:
     - name: Build app image
       run: docker build . --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-suite-runner
+        IMAGE_ID=ghcr.io/eiffel-community/etos-suite-runner
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -45,13 +49,17 @@ jobs:
     - name: Build app image
       run: docker build . -f Dockerfile.log_listener --tag image
 
-    - name: Log into registry
-      run: echo "${{ secrets.REGISTRYPASSWORD }}" | docker login registry.nordix.org -u ${{ secrets.REGISTRYUSERNAME }} --password-stdin
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push app image
       id: image
       run: |
-        IMAGE_ID=registry.nordix.org/eiffel/etos-log-listener
+        IMAGE_ID=ghcr.io/eiffel-community/etos-log-listener
         # Strip git ref prefix from version
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         # Strip "v" prefix from tag name
@@ -79,8 +87,8 @@ jobs:
         valueFile: 'manifests/base/kustomization.yaml'
         changes: |
           {
-            "configMapGenerator[0].literals[0]": "SUITE_RUNNER=registry.nordix.org/eiffel/etos-suite-runner:${{ needs.build_esr.outputs.esrVersion }}",
-            "configMapGenerator[0].literals[1]": "LOG_LISTENER=registry.nordix.org/eiffel/etos-log-listener:${{ needs.build_listener.outputs.logListenerVersion }}"
+            "configMapGenerator[0].literals[0]": "SUITE_RUNNER=ghcr.io/eiffel-community/etos-suite-runner:${{ needs.build_esr.outputs.esrVersion }}",
+            "configMapGenerator[0].literals[1]": "LOG_LISTENER=ghcr.io/eiffel-community/etos-log-listener:${{ needs.build_listener.outputs.logListenerVersion }}"
           }
         branch: main
         commitChange: true

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -7,6 +7,10 @@ on:
       - closed
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build_esr:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}

--- a/manifests/base/kustomization.yaml
+++ b/manifests/base/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 configMapGenerator:
   - name: etos-suite-starter
     literals:
-      - SUITE_RUNNER=registry.nordix.org/eiffel/etos-suite-runner:a81ce2bf
-      - LOG_LISTENER=registry.nordix.org/eiffel/etos-log-listener:a81ce2bf
+      - SUITE_RUNNER=ghcr.io/eiffel-community/etos-suite-runner:a81ce2bf
+      - LOG_LISTENER=ghcr.io/eiffel-community/etos-log-listener:a81ce2bf
 patches:
   - target:
       name: etos-suite-runner

--- a/projects/etos_suite_runner/tests/scenario/tercc.py
+++ b/projects/etos_suite_runner/tests/scenario/tercc.py
@@ -42,7 +42,7 @@ PERMUTATION_TERCC = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     }
@@ -70,7 +70,7 @@ PERMUTATION_TERCC = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     }
@@ -114,7 +114,7 @@ PERMUTATION_TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -136,7 +136,7 @@ PERMUTATION_TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -164,7 +164,7 @@ PERMUTATION_TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -186,7 +186,7 @@ PERMUTATION_TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -230,7 +230,7 @@ TERCC = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     }
@@ -274,7 +274,7 @@ TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },
@@ -296,7 +296,7 @@ TERCC_SUB_SUITES = {
                             },
                             {
                                 "key": "TEST_RUNNER",
-                                "value": "registry.nordix.org/eiffel/etos-python-test-runner:3.9.0",
+                                "value": "ghcr.io/eiffel-community/etos-python-test-runner:3.9.0",
                             },
                         ],
                     },

--- a/projects/etos_suite_runner/tests/scenario/test_permutations.py
+++ b/projects/etos_suite_runner/tests/scenario/test_permutations.py
@@ -114,7 +114,7 @@ class TestPermutationScenario(TestCase):
         """Set up environment variables for the ESR."""
         os.environ["ETOS_DISABLE_SENDING_EVENTS"] = "1"
         os.environ["ESR_WAIT_FOR_ENVIRONMENT_TIMEOUT"] = "20"
-        os.environ["SUITE_RUNNER"] = "registry.nordix.org/eiffel/etos-suite-runner"
+        os.environ["SUITE_RUNNER"] = "ghcr.io/eiffel-community/etos-suite-runner"
         os.environ["SOURCE_HOST"] = "localhost"
         Config().set("database", FakeDatabase())
 

--- a/projects/etos_suite_runner/tests/scenario/test_regular.py
+++ b/projects/etos_suite_runner/tests/scenario/test_regular.py
@@ -111,7 +111,7 @@ class TestRegularScenario(TestCase):
         """Set up environment variables for the ESR."""
         os.environ["ETOS_DISABLE_SENDING_EVENTS"] = "1"
         os.environ["ESR_WAIT_FOR_ENVIRONMENT_TIMEOUT"] = "20"
-        os.environ["SUITE_RUNNER"] = "registry.nordix.org/eiffel/etos-suite-runner"
+        os.environ["SUITE_RUNNER"] = "ghcr.io/eiffel-community/etos-suite-runner"
         os.environ["SOURCE_HOST"] = "localhost"
         Config().set("database", FakeDatabase())
 


### PR DESCRIPTION
### Applicable Issues
- https://github.com/eiffel-community/etos/issues/343

### Description of the Change
This change migrates ETOS Suite Runner container images from `nordix.org/eiffel` to `ghcr.io/eiffel-community`.


### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by:  Andrei Matveyeu, andrei.matveyeu@axis.com