### PR TITLE
More informative logging when calling release_full_environment()

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/esr.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/esr.py
@@ -196,12 +196,13 @@ class ESR(OpenTelemetryBase):  # pylint:disable=too-many-instance-attributes
         # Passing variables as keyword argument to make it easier to transition to a function where
         # jsontas is not required.
         jsontas = JsonTas()
-        span_name = "release_full_environment"
+        span_name = "release_full_environment (ESR)"
         with self.otel_tracer.start_as_current_span(
             span_name,
             context=self.otel_context,
             kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
+            self.logger.info("ESR._release_environment(): calling release_full_environment(), suite id: %s", self.params.testrun_id)
             status, message = release_full_environment(
                 etos=self.etos,
                 jsontas=jsontas,

--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/runner.py
@@ -57,12 +57,13 @@ class SuiteRunner(OpenTelemetryBase):  # pylint:disable=too-few-public-methods
         # Passing variables as keyword argument to make it easier to transition to a function where
         # jsontas is not required.
         jsontas = JsonTas()
-        span_name = "release_full_environment"
+        span_name = "release_full_environment (SuiteRunner)"
         with self.otel_tracer.start_as_current_span(
             span_name,
             context=self.otel_suite_context,
             kind=opentelemetry.trace.SpanKind.CLIENT,
         ):
+            self.logger.info("SuiteRunner._release_environment(): calling release_full_environment(), suite id: %s", self.params.testrun_id)
             status, message = release_full_environment(
                 etos=self.etos, jsontas=jsontas, suite_id=self.params.testrun_id
             )


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
We need more informative logging around release_full_environment() to troubleshoot recent issues.

With this change we make sure that:
- release_full_environment is logged in OpenTelemetry as two distinct spans depending where it is called (ESR() or SuiteRunner())
- ESR().params.testrun_id and SuiteRunner.params.testrun_id are recorded as a span attribute

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com