### PR TITLE
Remove in-service telemetry signals environment logic

### DIFF
--- a/projects/etos_suite_runner/pyproject.toml
+++ b/projects/etos_suite_runner/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "packageurl-python~=0.11",
     "cryptography>=42.0.4,<43.0.0",
     "etos_lib==5.1.2",
-    "etos_environment_provider==5.3.1",
+    "etos_environment_provider==5.3.2",
     "opentelemetry-api~=1.21",
     "opentelemetry-exporter-otlp~=1.21",
     "opentelemetry-sdk~=1.21",

--- a/projects/etos_suite_runner/pyproject.toml
+++ b/projects/etos_suite_runner/pyproject.toml
@@ -18,8 +18,8 @@ requires-python = ">=3.9"
 dependencies = [
     "packageurl-python~=0.11",
     "cryptography>=42.0.4,<43.0.0",
-    "etos_lib==4.5.0",
-    "etos_environment_provider==5.3.0",
+    "etos_lib==5.1.2",
+    "etos_environment_provider==5.3.1",
     "opentelemetry-api~=1.21",
     "opentelemetry-exporter-otlp~=1.21",
     "opentelemetry-sdk~=1.21",

--- a/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
@@ -22,7 +22,6 @@ from etos_lib.logging.logger import setup_logging
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import (
-    DEPLOYMENT_ENVIRONMENT,
     SERVICE_NAME,
     SERVICE_VERSION,
     OTELResourceDetector,
@@ -39,7 +38,6 @@ except PackageNotFoundError:
     VERSION = "Unknown"
 
 DEV = os.getenv("DEV", "false").lower() == "true"
-ENVIRONMENT = "development" if DEV else "production"
 os.environ["ENVIRONMENT_PROVIDER_DISABLE_LOGGING"] = "true"
 
 LOGGER = logging.getLogger(__name__)
@@ -60,7 +58,6 @@ if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
         {
             SERVICE_NAME: "etos-suite-runner",
             SERVICE_VERSION: VERSION,
-            DEPLOYMENT_ENVIRONMENT: ENVIRONMENT,
         },
     )
 
@@ -76,7 +73,7 @@ if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
     PROCESSOR = BatchSpanProcessor(EXPORTER)
     PROVIDER.add_span_processor(PROCESSOR)
     trace.set_tracer_provider(PROVIDER)
-    setup_logging("ETOS Suite Runner", VERSION, ENVIRONMENT, OTEL_RESOURCE)
+    setup_logging("ETOS Suite Runner", VERSION, OTEL_RESOURCE)
 else:
-    setup_logging("ETOS Suite Runner", VERSION, ENVIRONMENT)
+    setup_logging("ETOS Suite Runner", VERSION)
     LOGGER.info("OpenTelemetry not enabled. OTEL_COLLECTOR_HOST not set.")


### PR DESCRIPTION
### Description of the Change
Since the logic to figure out in what environment the service is running
is very limited, we remove the logic and let it be handled better
somewhere outside of the service.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
