### PR TITLE
Remove the OTEL_COLLECTOR_HOST variable

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/__init__.py
@@ -42,17 +42,6 @@ os.environ["ENVIRONMENT_PROVIDER_DISABLE_LOGGING"] = "true"
 
 LOGGER = logging.getLogger(__name__)
 
-# Setting OTEL_COLLECTOR_HOST will override the default OTEL collector endpoint.
-# This is needed because Suite Runner uses the cluster-level OpenTelemetry collector
-# instead of a sidecar collector.
-if os.getenv("OTEL_COLLECTOR_HOST"):
-    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = os.getenv("OTEL_COLLECTOR_HOST")
-elif "OTEL_EXPORTER_OTLP_ENDPOINT" in os.environ:
-    LOGGER.debug("Environment variable OTEL_EXPORTER_OTLP_ENDPOINT not used.")
-    LOGGER.debug("To specify an OpenTelemetry collector host use OTEL_COLLECTOR_HOST.")
-    del os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"]
-
-
 if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
     OTEL_RESOURCE = Resource.create(
         {
@@ -76,4 +65,4 @@ if os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"):
     setup_logging("ETOS Suite Runner", VERSION, otel_resource=OTEL_RESOURCE)
 else:
     setup_logging("ETOS Suite Runner", VERSION)
-    LOGGER.info("OpenTelemetry not enabled. OTEL_COLLECTOR_HOST not set.")
+    LOGGER.info("OpenTelemetry not enabled. OTEL_EXPORTER_OTLP_ENDPOINT not set.")


### PR DESCRIPTION
### Description of the Change
Remove the usage of, and logic surrounding the OTEL_COLLECTOR_HOST
variable. As a way to to uniform how we reference the OpenTelemetry
Collector, we are sending the OTEL_EXPORTER_OTLP_ENDPOINT directly to
the ESR job and thus removing the need of using OTEL_COLLECTOR_HOST as
an intermediary guard rail variable.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt <<fredrik.fristedt@axis.com>>
