### PR TITLE
Skip test result timeout in v1alpha controller mode

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -150,9 +150,14 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
                     self._record_exception(exception)
                     raise
                 self.logger.info("ETR triggered.")
-            timeout = time.time() + self.etos.debug.default_test_result_timeout
+            # In v1alpha (controller mode) the TestRun controller manages the
+            # deadline, so the suite runner should not enforce its own timeout.
+            if self.controller:
+                timeout = None
+            else:
+                timeout = time.time() + self.etos.debug.default_test_result_timeout
             try:
-                while time.time() < timeout:
+                while timeout is None or time.time() < timeout:
                     time.sleep(10)
                     if not self.started:
                         continue

--- a/projects/etos_suite_runner/tests/library/fake_database.py
+++ b/projects/etos_suite_runner/tests/library/fake_database.py
@@ -87,7 +87,7 @@ class FakeDatabase:
         # ttl is unused since we do not actually make the post request that the regular
         # etcd client does. First argument to `Lease` is the ID that was returned by the
         # etcd server.
-        return Lease(len(self.expire) - 1)
+        return Lease(len(self.expire) - 1, client=None)  # type: ignore[arg-type]
 
     def get(self, path: str) -> list[bytes]:
         """Get an item from database."""


### PR DESCRIPTION
### Applicable Issues

Related to https://github.com/eiffel-community/etos/issues/644

### Description of the Change

When running in controller mode (v1alpha), skip the `ETOS_DEFAULT_TEST_RESULT_TIMEOUT` so that the poll loop runs until the controller terminates the pod. The v0 code path is unchanged.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com