### PR TITLE
Bound wait for sub suite to start in controller mode

### DIFF
--- a/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
+++ b/projects/etos_suite_runner/src/etos_suite_runner/lib/suite.py
@@ -17,6 +17,7 @@
 
 import json
 import logging
+import os
 import threading
 import time
 from typing import Iterator, Union
@@ -156,10 +157,24 @@ class SubSuite(OpenTelemetryBase):  # pylint:disable=too-many-instance-attribute
                 timeout = None
             else:
                 timeout = time.time() + self.etos.debug.default_test_result_timeout
+            # Bound the wait for the sub suite to start so an execution space that is
+            # aborted before the test runner starts does not block until the deadline.
+            start_timeout = int(os.getenv("ETOS_SUB_SUITE_START_TIMEOUT", "1800"))
+            start_deadline = time.time() + start_timeout if self.controller else None
             try:
                 while timeout is None or time.time() < timeout:
                     time.sleep(10)
                     if not self.started:
+                        if start_deadline is not None and time.time() >= start_deadline:
+                            self.test_start_exception_caught = True
+                            self.logger.error(
+                                "Sub suite %r did not start within %ds. The execution "
+                                "space was likely aborted before the test runner started.",
+                                self.environment.get("name"),
+                                start_timeout,
+                                extra={"user_log": True},
+                            )
+                            break
                         continue
                     self.logger.info("ETOS test runner has started", extra={"user_log": True})
                     self.request_finished_event()


### PR DESCRIPTION
### Applicable Issues

Fixes https://github.com/eiffel-community/etos/issues/715

### Description of the Change

In controller mode the suite runner waited indefinitely for a sub suite to start, so an execution space aborted before the test runner started would keep the TestRun and its resources active until the deadline. The wait for a sub suite to start is now bounded by `ETOS_SUB_SUITE_START_TIMEOUT` (default 1800s); if it is exceeded the sub suite is marked failed and released. This complements eiffel-community/etos#705, which lets the generic Kubernetes execution space provider wait for the test runner to start, whereas this change covers the suite runner side that waits for the TestSuiteStarted event.

### Alternate Designs



### Possible Drawbacks



### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com