### PR TITLE
Update cryptography to >=50.0.0

### DIFF
--- a/projects/etos_suite_runner/pyproject.toml
+++ b/projects/etos_suite_runner/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 requires-python = ">=3.13"
 dependencies = [
     "packageurl-python~=0.11",
-    "cryptography>=42.0.4,<43.0.0",
+    "cryptography>=50.0.0,<51.0.0",
     # etos-lib version is determined by etos-environment-provider;
     # keep this as a loose lower bound to avoid diamond dependency conflicts.
     "etos_lib>=5.4.0,<6.0.0",

--- a/projects/etos_suite_runner/pyproject.toml
+++ b/projects/etos_suite_runner/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     # etos-lib version is determined by etos-environment-provider;
     # keep this as a loose lower bound to avoid diamond dependency conflicts.
     "etos_lib>=5.4.0,<6.0.0",
-    "etos_environment_provider==5.5.1",
+    "etos_environment_provider==5.5.2",
     "opentelemetry-api~=1.40",
     "opentelemetry-exporter-otlp~=1.40",
     "opentelemetry-sdk~=1.40",


### PR DESCRIPTION
### Applicable Issues

Related advisory: https://github.com/eiffel-community/etos-suite-runner/security/dependabot/11

This update is created manually because Dependabot cannot open an automated PR for this advisory due to the missing lockfile (the currently installed version can't be determined without a supported lockfile such as Pipfile.lock, pyproject.lock, or poetry.lock).

### Description of the Change

Bumps the `cryptography` dependency constraint from `>=42.0.4,<43.0.0` to `>=50.0.0,<51.0.0` to move to the current latest release, which is not affected by the exponential path-building advisory present in versions <= 48.0.0.

### Alternate Designs

### Possible Drawbacks

### Sign-off

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Andrei Matveyeu, andrei.matveyeu@axis.com